### PR TITLE
Fix issue with registries required fields

### DIFF
--- a/pkg/rke2/registries_types.go
+++ b/pkg/rke2/registries_types.go
@@ -54,10 +54,10 @@ type AuthConfig struct {
 
 // TLSConfig contains the CA/Cert/Key used for a registry.
 type TLSConfig struct {
-	CAFile             string `json:"ca_file"              toml:"ca_file"              yaml:"ca_file"`
-	CertFile           string `json:"cert_file"            toml:"cert_file"            yaml:"cert_file"`
-	KeyFile            string `json:"key_file"             toml:"key_file"             yaml:"key_file"`
-	InsecureSkipVerify bool   `json:"insecure_skip_verify" toml:"insecure_skip_verify" yaml:"insecure_skip_verify"`
+	CAFile             string `json:"ca_file,omitempty"              toml:"ca_file"              yaml:"ca_file,omitempty"`
+	CertFile           string `json:"cert_file,omitempty"            toml:"cert_file"            yaml:"cert_file,omitempty"`
+	KeyFile            string `json:"key_file,omitempty"             toml:"key_file"             yaml:"key_file,omitempty"`
+	InsecureSkipVerify bool   `json:"insecure_skip_verify,omitempty" toml:"insecure_skip_verify" yaml:"insecure_skip_verify,omitempty"`
 }
 
 // Registry is registry settings including mirrors, TLS, and credentials.


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

The registry TLS configuration requires the 3 values ca.crt, tls.crt, tls.key when only ca.crt is required (in case the registry does not need the client certs). With the current code, you're not able to include only the ca.crt. Also, there's no way to include the insecureSkipVerify flag to remove the rest of certs (we're skipping)


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
