### PR TITLE
Make CAPA templates variables compatible with clusterctl

### DIFF
--- a/samples/aws/README.md
+++ b/samples/aws/README.md
@@ -27,10 +27,8 @@ We will use the `internal` one for this guide, however the same steps apply for 
 You will need to set the following environment variables:
 
 ```bash
-export CLUSTER_NAMESPACE="cluster-namespace"
-export CLUSTER_NAME="cluster-name"
-export CABPR_CP_REPLICAS=3
-export CABPR_WK_REPLICAS=1
+export CONTROL_PLANE_MACHINE_COUNT=3
+export WORKER_MACHINE_COUNT=1
 export RKE2_VERSION=v1.26.0+rke2r1
 export AWS_NODE_MACHINE_TYPE=t3a.large
 export AWS_CONTROL_PLANE_MACHINE_TYPE=t3a.large 

--- a/samples/aws/external/cluster-template-external-cloud-provider.yaml
+++ b/samples/aws/external/cluster-template-external-cloud-provider.yaml
@@ -3,7 +3,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   name: ${CLUSTER_NAME}
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
   labels:
     ccm: external
     csi: external
@@ -25,7 +25,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSCluster
 metadata:
   name: ${CLUSTER_NAME}
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 spec:
   bastion:
     enabled: true
@@ -67,7 +67,7 @@ apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: RKE2ControlPlane
 metadata:
   name: ${CLUSTER_NAME}-control-plane
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 spec:
   version: ${RKE2_VERSION}
   preRKE2Commands:
@@ -79,7 +79,7 @@ spec:
     kind: AWSMachineTemplate
     name: ${CLUSTER_NAME}-control-plane
   nodeDrainTimeout: 2m
-  replicas: 3
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   serverConfig:
     cloudProviderName: external
     cni: calico
@@ -97,7 +97,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 spec:
   template:
     spec:
@@ -113,10 +113,10 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
   name: ${CLUSTER_NAME}-md-0
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 spec:
   clusterName: ${CLUSTER_NAME}
-  replicas: ${CABPR_WK_REPLICAS}
+  replicas: ${WORKER_MACHINE_COUNT}
   selector:
     matchLabels:
       cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
@@ -141,7 +141,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 spec:
   template:
     spec:
@@ -157,7 +157,7 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: RKE2ConfigTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 spec: 
   template:
     spec:
@@ -168,7 +168,7 @@ apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
   name: crs-ccm
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 spec:
   clusterSelector:
     matchLabels:
@@ -182,7 +182,7 @@ apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
   name: crs-csi
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 spec:
   clusterSelector:
     matchLabels:
@@ -372,7 +372,7 @@ metadata:
   labels:
     type: generated
   name: cloud-controller-manager-addon
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 ---
 apiVersion: v1
 data:
@@ -1018,14 +1018,14 @@ metadata:
   labels:
     type: generated
   name: aws-ebs-csi-driver-addon
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSClusterControllerIdentity
 metadata:
   name: default
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 spec:
   allowedNamespaces:
     list:
-    - ${CLUSTER_NAMESPACE}
+    - ${NAMESPACE}

--- a/samples/aws/ignition-external/cluster-template-aws-ignition-external-cloud-provider.yaml
+++ b/samples/aws/ignition-external/cluster-template-aws-ignition-external-cloud-provider.yaml
@@ -3,7 +3,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   name: ${CLUSTER_NAME}
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
   labels:
     ccm: external
     csi: external
@@ -25,7 +25,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSCluster
 metadata:
   name: ${CLUSTER_NAME}
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 spec:
   bastion:
     enabled: true
@@ -67,7 +67,7 @@ apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: RKE2ControlPlane
 metadata:
   name: ${CLUSTER_NAME}-control-plane
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 spec:
   version: ${RKE2_VERSION}
   preRKE2Commands:
@@ -77,7 +77,7 @@ spec:
     kind: AWSMachineTemplate
     name: ${CLUSTER_NAME}-control-plane
   nodeDrainTimeout: 2m
-  replicas: 3
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   serverConfig:
     cloudProviderName: external
     cni: calico
@@ -95,7 +95,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 spec:
   template:
     spec:
@@ -110,10 +110,10 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
   name: ${CLUSTER_NAME}-md-0
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 spec:
   clusterName: ${CLUSTER_NAME}
-  replicas: ${CABPR_WK_REPLICAS}
+  replicas: ${WORKER_MACHINE_COUNT}
   selector:
     matchLabels:
       cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
@@ -138,7 +138,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 spec:
   template:
     spec:
@@ -153,13 +153,13 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: RKE2ConfigTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
   name: crs-ccm
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 spec:
   clusterSelector:
     matchLabels:
@@ -173,7 +173,7 @@ apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
   name: crs-csi
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 spec:
   clusterSelector:
     matchLabels:
@@ -363,7 +363,7 @@ metadata:
   labels:
     type: generated
   name: cloud-controller-manager-addon
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 ---
 apiVersion: v1
 data:
@@ -1009,14 +1009,14 @@ metadata:
   labels:
     type: generated
   name: aws-ebs-csi-driver-addon
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSClusterControllerIdentity
 metadata:
   name: default
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 spec:
   allowedNamespaces:
     list:
-    - ${CLUSTER_NAMESPACE}
+    - ${NAMESPACE}

--- a/samples/aws/internal/cluster-template.yaml
+++ b/samples/aws/internal/cluster-template.yaml
@@ -3,7 +3,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   name: ${CLUSTER_NAME}
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 spec:
   clusterNetwork:
     pods:
@@ -22,7 +22,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSCluster
 metadata:
   name: ${CLUSTER_NAME}
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 spec:
   bastion:
     enabled: true
@@ -64,7 +64,7 @@ apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: RKE2ControlPlane
 metadata:
   name: ${CLUSTER_NAME}-control-plane
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 spec:
   version: ${RKE2_VERSION}
   preRKE2Commands:
@@ -76,7 +76,7 @@ spec:
     kind: AWSMachineTemplate
     name: ${CLUSTER_NAME}-control-plane
   nodeDrainTimeout: 2m
-  replicas: 3
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   serverConfig:
     cloudProviderName: aws
     cni: calico
@@ -94,7 +94,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 spec:
   template:
     spec:
@@ -110,10 +110,10 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
   name: ${CLUSTER_NAME}-md-0
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 spec:
   clusterName: ${CLUSTER_NAME}
-  replicas: ${CABPR_WK_REPLICAS}
+  replicas: ${WORKER_MACHINE_COUNT}
   selector:
     matchLabels:
       cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
@@ -138,7 +138,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 spec:
   template:
     spec:
@@ -154,7 +154,7 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: RKE2ConfigTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 spec: 
   template:
     spec:
@@ -165,9 +165,9 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSClusterControllerIdentity
 metadata:
   name: default
-  namespace: ${CLUSTER_NAMESPACE}
+  namespace: ${NAMESPACE}
 spec:
   allowedNamespaces:
     list:
-    - ${CLUSTER_NAMESPACE}
+    - ${NAMESPACE}
     


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Make CAPA templates variables compatible with clusterctl. Renaming these variables will allow using `clusterctl generate` flags for setting namespace, CP and worker machine count.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
