### PR TITLE
[release-0.5] Revert back legacy e2e tests to its original state

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -254,8 +254,8 @@ func initLegacyBootstrapCluster(bootstrapClusterProxy framework.ClusterProxy, co
 		InfrastructureProviders:   config.InfrastructureProviders(),
 		IPAMProviders:             config.IPAMProviders(),
 		RuntimeExtensionProviders: config.RuntimeExtensionProviders(),
-		BootstrapProviders:        []string{"rke2-bootstrap:v0.3.0"},
-		ControlPlaneProviders:     []string{"rke2-control-plane:v0.3.0"},
+		BootstrapProviders:        []string{"rke2-bootstrap:v0.2.7"},
+		ControlPlaneProviders:     []string{"rke2-control-plane:v0.2.7"},
 		LogFolder:                 filepath.Join(artifactFolder, "clusters", bootstrapClusterProxy.GetName()),
 	}, config.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
 }

--- a/test/e2e/e2e_upgrade_test.go
+++ b/test/e2e/e2e_upgrade_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Workload cluster creation", func() {
 	})
 
 	Context("Creating a single control-plane cluster", func() {
-		It("Should create a cluster with legacy version and perform upgrade with the current version", func() {
+		It("Should create a cluster with legacy version and perform upgrade to the v0.3.0 version", func() {
 			By("Installing legacy version")
 			initLegacyBootstrapCluster(bootstrapClusterProxy, e2eConfig, clusterctlConfigPath, artifactFolder)
 
@@ -115,21 +115,12 @@ var _ = Describe("Workload cluster creation", func() {
 				ControlPlane: client.ObjectKeyFromObject(result.LegacyControlPlane),
 			}, e2eConfig.GetIntervals(specName, "wait-control-plane")...)
 
-			By("Upgrading to v0.4.0 boostrap/controlplane provider version")
+			By("Upgrading to v0.3.0 boostrap/controlplane provider version")
 			clusterctl.UpgradeManagementClusterAndWait(ctx, clusterctl.UpgradeManagementClusterAndWaitInput{
 				ClusterProxy:          bootstrapClusterProxy,
 				ClusterctlConfigPath:  clusterctlConfigPath,
-				BootstrapProviders:    []string{"rke2-bootstrap:v0.4.0"},
-				ControlPlaneProviders: []string{"rke2-control-plane:v0.4.0"},
-				LogFolder:             clusterctlLogFolder,
-			}, e2eConfig.GetIntervals(specName, "wait-controllers")...)
-
-			By("Upgrading to current boostrap/controlplane provider version")
-			clusterctl.UpgradeManagementClusterAndWait(ctx, clusterctl.UpgradeManagementClusterAndWaitInput{
-				ClusterProxy:          bootstrapClusterProxy,
-				ClusterctlConfigPath:  clusterctlConfigPath,
-				BootstrapProviders:    []string{"rke2-bootstrap:v0.5.99"},
-				ControlPlaneProviders: []string{"rke2-control-plane:v0.5.99"},
+				BootstrapProviders:    []string{"rke2-bootstrap:v0.3.0"},
+				ControlPlaneProviders: []string{"rke2-control-plane:v0.3.0"},
 				LogFolder:             clusterctlLogFolder,
 			}, e2eConfig.GetIntervals(specName, "wait-controllers")...)
 


### PR DESCRIPTION
Signed-off-by: Furkat Gofurov <furkat.gofurov@suse.com>
(cherry picked from commit 7ed376e41e979698cee7d3201654491c4fcad36b)

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes: #391 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
