### PR TITLE
Fix cisProfile option with ignition format

### DIFF
--- a/bootstrap/internal/ignition/butane/butane.go
+++ b/bootstrap/internal/ignition/butane/butane.go
@@ -38,9 +38,8 @@ import (
 // The rke2-install.service unit is enabled and is executed only once during the boot process to run the /etc/rke2-install.sh script.
 // This script installs and deploys RKE2, and performs pre and post-installation commands.
 // The ntpd.service unit is enabled only if NTP servers are specified.
-// The second section defines storage files for the system. It creates a file at /etc/rke2-install.sh. If CISEnabled is set to true,
-// it runs an additional CIS script to enforce system security standards. If NTP servers are specified,
-// it creates an NTP configuration file at /etc/ntp.conf.
+// The second section defines storage files for the system. It creates a file at /etc/rke2-install.sh.
+// If NTP servers are specified, it creates an NTP configuration file at /etc/ntp.conf.
 const (
 	butaneTemplate = `
 variant: fcos
@@ -113,10 +112,6 @@ storage:
           {{ range .PreRKE2Commands }}
           {{ . | Indent 10 }}
           {{- end }}
-
-		  {{- if .CISEnabled }}
-  		  /opt/rke2-cis-script.sh
-		  {{ end }}
 
           {{ range .DeployRKE2Commands }}
           {{ . | Indent 10 }}

--- a/bootstrap/internal/ignition/butane/butane.go
+++ b/bootstrap/internal/ignition/butane/butane.go
@@ -66,6 +66,13 @@ systemd:
       enabled: true
     {{- end }}
 storage:
+  filesystems:
+    - path: /opt
+      device: "/dev/disk/by-partlabel/p.lxroot"
+      format: btrfs
+      wipe_filesystem: false
+      mount_options:
+       - "subvol=/@/opt"
   files:
     - path: /etc/ssh/sshd_config
       mode: 0600

--- a/bootstrap/internal/ignition/ignition.go
+++ b/bootstrap/internal/ignition/ignition.go
@@ -29,6 +29,7 @@ const (
 	controlPlaneCommand          = "curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION=%[1]s sh -s - server"
 	airGappedWorkerCommand       = "INSTALL_RKE2_ARTIFACT_PATH=/opt/rke2-artifacts INSTALL_RKE2_TYPE=\"agent\" sh /opt/install.sh"
 	workerCommand                = "curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION=%[1]s INSTALL_RKE2_TYPE=\"agent\" sh -s -"
+	cisPreparationCommand        = "/opt/rke2-cis-script.sh"
 )
 
 var (
@@ -169,6 +170,11 @@ func getRKE2Commands(baseUserData *cloudinit.BaseUserData, command, airgappedCom
 		rke2Commands = append(rke2Commands, airgappedCommand)
 	} else {
 		rke2Commands = append(rke2Commands, fmt.Sprintf(command, baseUserData.RKE2Version))
+	}
+
+	// If CISEnabled is set to true we run an additional script for CIS mode pre-requisite config
+	if baseUserData.CISEnabled {
+		rke2Commands = append(rke2Commands, cisPreparationCommand)
 	}
 
 	rke2Commands = append(rke2Commands, systemdServices...)

--- a/pkg/consts/global_consts.go
+++ b/pkg/consts/global_consts.go
@@ -46,5 +46,5 @@ const (
 	DefaultFileMode = "0644"
 
 	// FileModeRootExecutable is the mode of the files created by the controller when the owner is root.
-	FileModeRootExecutable = "700"
+	FileModeRootExecutable = "0700"
 )

--- a/pkg/rke2/config.go
+++ b/pkg/rke2/config.go
@@ -55,6 +55,7 @@ fi
 
 YUM_BASED_PARAM_FILE_FOUND=false
 TAR_BASED_PARAM_FILE_FOUND=false
+INSTALLER_BASED_PARAM_FILE_FOUND=false
 
 # Using RKE2 generated kernel parameters
 if [ -f /usr/share/rke2/rke2-cis-sysctl.conf ]; then
@@ -67,7 +68,12 @@ if [ -f /usr/local/share/rke2/rke2-cis-sysctl.conf ]; then
 		cp -f /usr/local/share/rke2/rke2-cis-sysctl.conf /etc/sysctl.d/90-rke2-cis.conf
 fi
 
-if [ "$YUM_BASED_PARAM_FILE_FOUND" = false ] && [ "$TAR_BASED_PARAM_FILE_FOUND" = false ]; then
+if [ -f /opt/rke2/share/rke2/rke2-cis-sysctl.conf ]; then
+		INSTALLER_BASED_PARAM_FILE_FOUND=true
+		cp -f /opt/rke2/share/rke2/rke2-cis-sysctl.conf /etc/sysctl.d/90-rke2-cis.conf
+fi
+
+if [ "$YUM_BASED_PARAM_FILE_FOUND" = false ] && [ "$TAR_BASED_PARAM_FILE_FOUND" = false ] && [ "$INSTALLER_BASED_PARAM_FILE_FOUND" = false ]; then
 		echo "No kernel parameters file found"
 		exit 1
 fi


### PR DESCRIPTION
Currently there are some stray tabs which break the rendered output, replace these with spaces and add some unit test coverage.

kind/bug

**What this PR does / why we need it**:

Currently the cisProfile option is broken when selecting ignition format for Leap/SLEMicro deployments

Fixes: #401


**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [X] adds unit tests
- [ ] adds or updates e2e tests
