### PR TITLE
fix: use absolute path to rke2's kubectl binary

### DIFF
--- a/bootstrap/internal/cloudinit/controlplane_init.go
+++ b/bootstrap/internal/cloudinit/controlplane_init.go
@@ -37,7 +37,7 @@ runcmd:
   - '/opt/rke2-cis-script.sh'{{ end }}
   - 'systemctl enable rke2-server.service'
   - 'systemctl start rke2-server.service'
-  - 'kubectl create secret tls cluster-etcd -o yaml --dry-run=client -n kube-system --cert=/var/lib/rancher/rke2/server/tls/etcd/server-ca.crt --key=/var/lib/rancher/rke2/server/tls/etcd/server-ca.key --kubeconfig /etc/rancher/rke2/rke2.yaml | kubectl apply -f- --kubeconfig /etc/rancher/rke2/rke2.yaml'
+  - '/var/lib/rancher/rke2/bin/kubectl create secret tls cluster-etcd -o yaml --dry-run=client -n kube-system --cert=/var/lib/rancher/rke2/server/tls/etcd/server-ca.crt --key=/var/lib/rancher/rke2/server/tls/etcd/server-ca.key --kubeconfig /etc/rancher/rke2/rke2.yaml | /var/lib/rancher/rke2/bin/kubectl apply -f- --kubeconfig /etc/rancher/rke2/rke2.yaml'
   - 'mkdir -p /run/cluster-api'
   - '{{ .SentinelFileCommand }}'
 {{- template "commands" .PostRKE2Commands }}

--- a/bootstrap/internal/ignition/ignition.go
+++ b/bootstrap/internal/ignition/ignition.go
@@ -37,10 +37,10 @@ var (
 		"setenforce 0",
 		"systemctl enable rke2-server.service",
 		"systemctl start rke2-server.service",
-		"kubectl create secret tls cluster-etcd -o yaml --dry-run=client -n kube-system " +
+		"/var/lib/rancher/rke2/bin/kubectl create secret tls cluster-etcd -o yaml --dry-run=client -n kube-system " +
 			"--cert=/var/lib/rancher/rke2/server/tls/etcd/server-ca.crt --key=/var/lib/rancher/rke2/server/tls/etcd/server-ca.key " +
 			"--kubeconfig /etc/rancher/rke2/rke2.yaml |" +
-			" kubectl apply -f- --kubeconfig /etc/rancher/rke2/rke2.yaml",
+			" /var/lib/rancher/rke2/bin/kubectl apply -f- --kubeconfig /etc/rancher/rke2/rke2.yaml",
 		"restorecon /etc/systemd/system/rke2-server.service",
 		"mkdir -p /run/cluster-api /etc/cluster-api",
 		"echo success | tee /run/cluster-api/bootstrap-success.complete /etc/cluster-api/bootstrap-success.complete > /dev/null",


### PR DESCRIPTION
ensures that cluster-etcd secret can be created if host does not have kubectl installed

fixes #403

kind/bug

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
