### PR TITLE
Overwrite files with format: ignition

### DIFF
--- a/bootstrap/internal/ignition/butane/butane.go
+++ b/bootstrap/internal/ignition/butane/butane.go
@@ -95,6 +95,7 @@ storage:
       {{ if ne .Permissions "" -}}
       mode: {{ .Permissions }}
       {{ end -}}
+      overwrite: true
       contents:
         {{ if eq .Encoding "base64" -}}
         inline: !!binary |


### PR DESCRIPTION
This aligns with the [default cloud-init behavior](https://cloudinit.readthedocs.io/en/latest/reference/modules.html#write-files) and enables e.g overwriting distro-default files via RKE2ConfigTemplate using the spec.template.spec.files API.

With this we can see the example mentioned in #410 now works as expected the empty `/etc/motd` is overwritten.

```
worker-0 login: root
Password: 
hello 123
```

kind/bug
Fixes #410 

