### PR TITLE
Avoid deleting etcd member before node is drained

### DIFF
--- a/controlplane/internal/controllers/scale.go
+++ b/controlplane/internal/controllers/scale.go
@@ -151,20 +151,6 @@ func (r *RKE2ControlPlaneReconciler) scaleDownControlPlane(
 		return ctrl.Result{}, errors.New("failed to pick control plane Machine to delete")
 	}
 
-	// If etcd leadership is on machine that is about to be deleted, move it to the newest member available.
-	etcdLeaderCandidate := controlPlane.Machines.Newest()
-	if err := r.workloadCluster.ForwardEtcdLeadership(ctx, machineToDelete, etcdLeaderCandidate); err != nil {
-		logger.Error(err, "Failed to move leadership to candidate machine", "candidate", etcdLeaderCandidate.Name)
-
-		return ctrl.Result{}, err
-	}
-
-	if err := r.workloadCluster.RemoveEtcdMemberForMachine(ctx, machineToDelete); err != nil {
-		logger.Error(err, "Failed to remove etcd member for machine")
-
-		return ctrl.Result{}, err
-	}
-
 	logger = logger.WithValues("machine", machineToDelete)
 	if err := r.Client.Delete(ctx, machineToDelete); err != nil && !apierrors.IsNotFound(err) {
 		logger.Error(err, "Failed to delete control plane machine")


### PR DESCRIPTION
Control plane machines should not be removed from etcd cluster until the node is drained, otherwise kubelet would loose connectivity to the API, as it relies on local api-server, which in turn relies on local etcd pod.

If this etcd member is removed from the cluster, kubelet won't be able to report status to the API, and node won't be properly drained.

The cleanup of removed node will be done by periodic call of [reconcileEtcdMembers](https://github.com/rancher/cluster-api-provider-rke2/blob/967b2da50d7869d08da4b1adf6b090599cfe9c16/controlplane/internal/controllers/rke2controlplane_controller.go#L513) once the node is removed from api by capi controller.

We've observed significant improvements while testing the proposed change in https://gitlab.com/sylva-projects/sylva-core/-/merge_requests/2845.

kind/bug
fixes #431
