### PR TITLE
bootstrap: switch to chrony for ignition config

### DIFF
--- a/bootstrap/internal/ignition/butane/butane_test.go
+++ b/bootstrap/internal/ignition/butane/butane_test.go
@@ -115,14 +115,14 @@ var _ = Describe("Render", func() {
 
 		Expect(ign.Storage.Files[3].Path).To(Equal("/etc/rke2-install.sh"))
 
-		Expect(ign.Storage.Files[4].Path).To(Equal("/etc/ntp.conf"))
+		Expect(ign.Storage.Files[4].Path).To(Equal("/etc/chrony.conf"))
 
 		Expect(ign.Systemd.Units).To(HaveLen(3))
 		Expect(ign.Systemd.Units[0].Name).To(Equal("rke2-install.service"))
 		Expect(ign.Systemd.Units[0].Contents).To(Equal(pointer.String("[Unit]\nDescription=rke2-install\nWants=network-online.target\nAfter=network-online.target network.target\nConditionPathExists=!/etc/cluster-api/bootstrap-success.complete\n[Service]\nUser=root\n# To not restart the unit when it exits, as it is expected.\nType=oneshot\nExecStart=/etc/rke2-install.sh\n[Install]\nWantedBy=multi-user.target\n")))
 		Expect(ign.Systemd.Units[0].Enabled).To(Equal(pointer.Bool(true)))
 
-		Expect(ign.Systemd.Units[1].Name).To(Equal("ntpd.service"))
+		Expect(ign.Systemd.Units[1].Name).To(Equal("chronyd.service"))
 		Expect(ign.Systemd.Units[1].Enabled).To(Equal(pointer.Bool(true)))
 
 		Expect(ign.Systemd.Units[2].Name).To(Equal("test.service"))


### PR DESCRIPTION
Leap/SLEMicro don't include ntpd so the current approach doesn't work

kind/bug

**What this PR does / why we need it**:
Currently the `ntp.servers` API provided e.g by `RKE2ControlPlane` does not work for Leap/SLEMicro, because chrony is used not ntpd as currently configured.

Fixes #430

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
