### PR TITLE
🐛 Prevent machine re-rollout on system agent start command

### DIFF
--- a/pkg/rke2/machine_filters.go
+++ b/pkg/rke2/machine_filters.go
@@ -76,7 +76,7 @@ func matchesRKE2BootstrapConfig(machineConfigs map[string]*bootstrapv1.RKE2Confi
 			cmds := []string{}
 
 			for _, cmd := range machineConfig.Spec.PostRKE2Commands { // Filter out commands that are injected by the Rancher Turtles webhook
-				if cmd == "sudo sh /opt/system-agent-install.sh" {
+				if cmd == "sh /opt/system-agent-install.sh" {
 					continue
 				}
 


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This agent installation command is not executed during bootstrap process, due to `sudo` prefix. Changing it to a correct command, causes machines to re-rollout after successful bootstrap endlessly.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of https://github.com/rancher/turtles/issues/763

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
