### PR TITLE
Always use CAPI generated certificates for etcd management

### DIFF
--- a/bootstrap/internal/cloudinit/controlplane_init.go
+++ b/bootstrap/internal/cloudinit/controlplane_init.go
@@ -37,7 +37,6 @@ runcmd:
   - '/opt/rke2-cis-script.sh'{{ end }}
   - 'systemctl enable rke2-server.service'
   - 'systemctl start rke2-server.service'
-  - '/var/lib/rancher/rke2/bin/kubectl create secret tls cluster-etcd -o yaml --dry-run=client -n kube-system --cert=/var/lib/rancher/rke2/server/tls/etcd/server-ca.crt --key=/var/lib/rancher/rke2/server/tls/etcd/server-ca.key --kubeconfig /etc/rancher/rke2/rke2.yaml | /var/lib/rancher/rke2/bin/kubectl apply -f- --kubeconfig /etc/rancher/rke2/rke2.yaml'
   - 'mkdir -p /run/cluster-api'
   - '{{ .SentinelFileCommand }}'
 {{- template "commands" .PostRKE2Commands }}

--- a/bootstrap/internal/ignition/ignition.go
+++ b/bootstrap/internal/ignition/ignition.go
@@ -38,10 +38,6 @@ var (
 		"setenforce 0",
 		"systemctl enable rke2-server.service",
 		"systemctl start rke2-server.service",
-		"/var/lib/rancher/rke2/bin/kubectl create secret tls cluster-etcd -o yaml --dry-run=client -n kube-system " +
-			"--cert=/var/lib/rancher/rke2/server/tls/etcd/server-ca.crt --key=/var/lib/rancher/rke2/server/tls/etcd/server-ca.key " +
-			"--kubeconfig /etc/rancher/rke2/rke2.yaml |" +
-			" /var/lib/rancher/rke2/bin/kubectl apply -f- --kubeconfig /etc/rancher/rke2/rke2.yaml",
 		"restorecon /etc/systemd/system/rke2-server.service",
 		"mkdir -p /run/cluster-api /etc/cluster-api",
 		"echo success | tee /run/cluster-api/bootstrap-success.complete /etc/cluster-api/bootstrap-success.complete > /dev/null",

--- a/bootstrap/internal/ignition/ignition_test.go
+++ b/bootstrap/internal/ignition/ignition_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package ignition
 
 import (
-	"fmt"
-	"compress/gzip"
 	"bytes"
-	"io/ioutil"
+	"compress/gzip"
 	"encoding/base64"
+	"fmt"
+	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -133,7 +133,7 @@ var _ = Describe("NewJoinWorker", func() {
 		scriptContentsGzip, err := base64.StdEncoding.DecodeString(scriptContentsEnc)
 		Expect(err).ToNot(HaveOccurred())
 		reader := bytes.NewReader(scriptContentsGzip)
-		gzreader, err := gzip.NewReader(reader);
+		gzreader, err := gzip.NewReader(reader)
 		Expect(err).ToNot(HaveOccurred())
 		scriptContents, err := ioutil.ReadAll(gzreader)
 		Expect(err).ToNot(HaveOccurred())
@@ -254,7 +254,7 @@ var _ = Describe("getControlPlaneRKE2Commands", func() {
 	It("should return slice of control plane commands", func() {
 		commands, err := getControlPlaneRKE2Commands(baseUserData)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(commands).To(HaveLen(10))
+		Expect(commands).To(HaveLen(9))
 		Expect(commands).To(ContainElements(fmt.Sprintf(controlPlaneCommand, baseUserData.RKE2Version), serverDeployCommands[0], serverDeployCommands[1]))
 	})
 
@@ -262,7 +262,7 @@ var _ = Describe("getControlPlaneRKE2Commands", func() {
 		baseUserData.AirGapped = true
 		commands, err := getControlPlaneRKE2Commands(baseUserData)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(commands).To(HaveLen(10))
+		Expect(commands).To(HaveLen(9))
 		Expect(commands).To(ContainElements(airGappedControlPlaneCommand, serverDeployCommands[0], serverDeployCommands[1]))
 	})
 
@@ -271,7 +271,7 @@ var _ = Describe("getControlPlaneRKE2Commands", func() {
 		baseUserData.AirGappedChecksum = "abcd"
 		commands, err := getControlPlaneRKE2Commands(baseUserData)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(commands).To(HaveLen(11))
+		Expect(commands).To(HaveLen(10))
 		Expect(commands).To(ContainElements(fmt.Sprintf(airGappedChecksumCommand, "abcd"), airGappedControlPlaneCommand, serverDeployCommands[0], serverDeployCommands[1]))
 	})
 

--- a/pkg/rke2/workload_cluster.go
+++ b/pkg/rke2/workload_cluster.go
@@ -115,17 +115,9 @@ func (m *Management) NewWorkload(
 	}
 
 	if apierrors.IsNotFound(err) || etcdKeyPair == nil {
-		log.FromContext(ctx).Info("Collecting etcd key pair from remote")
+		log.FromContext(ctx).Info("Cluster does not provide etcd certificates for creating child etcd ctrlclient.")
 
-		etcdKeyPair, err = m.getRemoteKeyPair(ctx, cl, clusterKey)
-		if ctrlclient.IgnoreNotFound(err) != nil {
-			return nil, err
-		} else if apierrors.IsNotFound(err) {
-			log.FromContext(ctx).Info("Cluster does not provide etcd certificates for creating child etcd ctrlclient." +
-				"Please scale up the CP nodes by one to bootstrap the etcd secret content.")
-
-			return workload, nil
-		}
+		return workload, nil
 	}
 
 	clientCert, err := tls.X509KeyPair(etcdKeyPair.Cert, etcdKeyPair.Key)


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This change ensures that in all cases, etcd certificate is fetched from local (management) cluster, to perform etcd membership management, unless the certificate is not available, which skips this operation.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #449 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
