### PR TITLE
Fix: remove pre-terminate drain hook for legacy CP

### DIFF
--- a/controlplane/internal/controllers/rke2controlplane_controller.go
+++ b/controlplane/internal/controllers/rke2controlplane_controller.go
@@ -1000,13 +1000,12 @@ func (r *RKE2ControlPlaneReconciler) reconcilePreTerminateHook(ctx context.Conte
 
 	// The following will execute and remove the pre-terminate hook from the Machine.
 
+	// Skip leader change for legacy CP
+	_, found := controlPlane.RCP.Annotations[controlplanev1.LegacyRKE2ControlPlane]
+
 	// If we have more than 1 Machine and etcd is managed we forward etcd leadership and remove the member
 	// to keep the etcd cluster healthy.
-	if controlPlane.Machines.Len() > 1 {
-		if _, found := controlPlane.RCP.Annotations[controlplanev1.LegacyRKE2ControlPlane]; found {
-			return ctrl.Result{}, nil
-		}
-
+	if controlPlane.Machines.Len() > 1 && !found {
 		workloadCluster, err := r.GetWorkloadCluster(ctx, controlPlane)
 		if err != nil {
 			return ctrl.Result{}, errors.Wrapf(err,


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Fixes an issue during deletion of RKE2 CP annotated with `controlplane.cluster.x-k8s.io/legacy`, allowing pre-terminate node drain hook to be removed as usual.

Requires a cherry-pick on release-0.7

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
