### PR TITLE
Fix repo path for reading a secret from vault

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,8 @@ jobs:
       uses: rancher-eio/read-vault-secrets@main
       with:
         secrets: |
-          secret/data/github/repo/${{ inputs.github_repository_for_docker }}/registry/prime/rancher/cluster-api-controller/credentials username | DOCKER_USERNAME;
-          secret/data/github/repo/${{ inputs.github_repository_for_docker }}/registry/prime/rancher/cluster-api-controller/credentials password | DOCKER_PASSWORD;
+          secret/data/github/repo/${{ github.repository }}/registry/prime/rancher/cluster-api-controller/credentials username | DOCKER_USERNAME ;
+          secret/data/github/repo/${{ github.repository }}/registry/prime/rancher/cluster-api-controller/credentials password | DOCKER_PASSWORD
     - name: Docker login to registry
       uses: docker/login-action@v3
       with:


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Path for secret read from vault seems to be incorrect compared to https://github.com/rancher-eio/read-vault-secrets?tab=readme-ov-file#example-workflow. 
Another example: https://github.com/rancher/backup-restore-operator/blob/5cc7bccaeaa6fcb44a8bc8ede18a53dfbe1ad9f6/.github/workflows/publish.yaml#L58

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
