### PR TITLE
[release-0.7] Revert prime image building changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   TAG: ${{ github.ref_name }}
-  GHCR_REGISTRY: ghcr.io
+  REGISTRY: ghcr.io
 
 jobs:
   build:
@@ -15,8 +15,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      actions: read
-      id-token: write
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -26,32 +24,16 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: '=1.21.8'
-    - name: Docker login ghcr.io
+    - name: Docker login
       uses: docker/login-action@v3
       with:
-        registry: ${{ env.GHCR_REGISTRY }}
+        registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build docker image for ghcr.io
+    - name: Build docker image
       run: make docker-build-all TAG=${{ env.TAG }}
-    - name: Push docker image to ghcr.io
-      run: make docker-push-all TAG=${{ env.TAG }} PROD_REGISTRY=${{ env.GHCR_REGISTRY }}
-    - name: Read prime registry secrets
-      uses: rancher-eio/read-vault-secrets@main
-      with:
-        secrets: |
-          secret/data/github/repo/clusterapi-forks/registry/prime/rancher/cluster-api-controller/credentials username | DOCKER_USERNAME ;
-          secret/data/github/repo/clusterapi-forks/registry/prime/rancher/cluster-api-controller/credentials password | DOCKER_PASSWORD
-    - name: Docker login to registry
-      uses: docker/login-action@v3
-      with:
-        registry: ${{ vars.PRIME_REGISTRY }}
-        username: ${{ env.DOCKER_USERNAME }}
-        password: ${{ env.DOCKER_PASSWORD }}
-    - name: Build docker image for prime registry
-      run: make docker-build-all TAG=${{ env.TAG }}
-    - name: Push docker image to prime registry
-      run: make docker-push-all TAG=${{ env.TAG }} PROD_REGISTRY=${{ vars.PRIME_REGISTRY }}
+    - name: Push docker image
+      run: make docker-push-all TAG=${{ env.TAG }} PROD_REGISTRY=${{ env.REGISTRY }}
   release:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
**What this PR does / why we need it**:
Reverts: #463, #464, #465 and https://github.com/rancher/cluster-api-provider-rke2/pull/459/commits/c902e98efc7f6a64bb05e52f021b04a76bbff932 from #459 to unblock release GH temporarily. 
Prime image building needs to be added back once we sort out secret creation in vault by EIO.


<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
