### PR TITLE
Patch legacy annotation on pre 0.3 RKE2 control planes

### DIFF
--- a/controlplane/api/v1alpha1/rke2controlplane_types.go
+++ b/controlplane/api/v1alpha1/rke2controlplane_types.go
@@ -33,6 +33,10 @@ const (
 	// RKE2ServerConfigurationAnnotation is a machine annotation that stores the json-marshalled string of RKE2Config
 	// This annotation is used to detect any changes in RKE2Config and trigger machine rollout.
 	RKE2ServerConfigurationAnnotation = "controlplane.cluster.x-k8s.io/rke2-server-configuration"
+
+	// LegacyRKE2ControlPlane is a controlplane annotation that marks the CP as legacy. This CP will not provide
+	// etcd certificate management or etcd membership management.
+	LegacyRKE2ControlPlane = "controlplane.cluster.x-k8s.io/legacy"
 )
 
 // RKE2ControlPlaneSpec defines the desired state of RKE2ControlPlane.

--- a/controlplane/internal/controllers/rke2controlplane_controller.go
+++ b/controlplane/internal/controllers/rke2controlplane_controller.go
@@ -386,6 +386,12 @@ func (r *RKE2ControlPlaneReconciler) reconcileNormal(
 	logger := log.FromContext(ctx)
 	logger.Info("Reconcile RKE2 Control Plane")
 
+	if rcp.Annotations == nil {
+		rcp.Annotations = map[string]string{}
+	}
+
+	rcp.Annotations[controlplanev1.LegacyRKE2ControlPlane] = ""
+
 	// Wait for the cluster infrastructure to be ready before creating machines
 	if !cluster.Status.InfrastructureReady {
 		logger.Info("Cluster infrastructure is not ready yet")
@@ -526,6 +532,12 @@ func (r *RKE2ControlPlaneReconciler) reconcileDelete(ctx context.Context,
 	rcp *controlplanev1.RKE2ControlPlane,
 ) (res ctrl.Result, err error) {
 	logger := log.FromContext(ctx)
+
+	if rcp.Annotations == nil {
+		rcp.Annotations = map[string]string{}
+	}
+
+	rcp.Annotations[controlplanev1.LegacyRKE2ControlPlane] = ""
 
 	// Gets all machines, not just control plane machines.
 	allMachines, err := r.managementCluster.GetMachinesForCluster(ctx, util.ObjectKey(cluster))


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

It is not always possible to apply annotation in some environments, so this patch and release can automate it.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Ensure that legacy CP contain annotation after upgrade to `v0.2.8`.

cc @alexander-demicev 

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
