### PR TITLE
Build and Push Prime images using prime registry secrets from vault

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   TAG: ${{ github.ref_name }}
-  REGISTRY: ghcr.io
+  GHCR_REGISTRY: ghcr.io
 
 jobs:
   build:
@@ -15,6 +15,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      actions: read
+      id-token: write
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -24,16 +26,33 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: '=1.21.8'
-    - name: Docker login
+    - name: Docker login ghcr.io
       uses: docker/login-action@v3
       with:
-        registry: ${{ env.REGISTRY }}
+        registry: ${{ env.GHCR_REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build docker image
+    - name: Build docker image for ghcr.io
       run: make docker-build-all TAG=${{ env.TAG }}
-    - name: Push docker image
-      run: make docker-push-all TAG=${{ env.TAG }} PROD_REGISTRY=${{ env.REGISTRY }}
+    - name: Push docker image to ghcr.io
+      run: make docker-push-all TAG=${{ env.TAG }} PROD_REGISTRY=${{ env.GHCR_REGISTRY }}
+    - name: Read prime registry secrets
+      uses: rancher-eio/read-vault-secrets@main
+      with:
+        secrets: |
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials username |  PRIME-REGISTRY-USERNAME;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password |  PRIME-REGISTRY-PASSWORD;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials registry |  PRIME-REGISTRY-REGISTRY;
+    - name: Docker login to prime registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.PRIME-REGISTRY-REGISTRY }}
+        username: ${{ env.PRIME-REGISTRY-USERNAME }}
+        password: ${{ env.PRIME-REGISTRY-PASSWORD }}
+    - name: Build docker image for prime registry
+      run: make docker-build-all TAG=${{ env.TAG }}
+    - name: Push docker image to prime registry
+      run: make docker-push-all TAG=${{ env.TAG }} PROD_REGISTRY=${{ env.PRIME-REGISTRY-REGISTRY }}
   release:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
**What this PR does / why we need it**:
Second try to enable Prime image building previously reverted due to issue with secret reading from EIO vault.
Based off https://github.com/rancher/cluster-api-provider-rke2/commit/c902e98efc7f6a64bb05e52f021b04a76bbff932 and slight changes on top of original one

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
As usual, this patch is not possible to test on CI nor on fork 😞 but I am hoping for it to work
Related to: https://github.com/rancherlabs/eio/issues/2696

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
