### PR TITLE
feat: Improvements to make image buildings faster

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
     // Features to add to the dev container. More info: https://containers.dev/features.
     "features": {
         "ghcr.io/devcontainers/features/go:1": {
-            "version": "1.21"
+            "version": "1.22"
         },
         "ghcr.io/devcontainers/features/docker-in-docker:2": {},
         "ghcr.io/mpriscella/features/kind:1": {},

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           check-latest: true
           cache: true
       - name: Verify

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Build e2e image
         run: make e2e-image
       - uses: actions/cache@v4.1.1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Setup kind
         uses: helm/kind-action@v1.10.0
         with:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.8
+          go-version: 1.22.8
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6.1.1
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.8
+          go-version: 1.22.8
       - name: Lint
         run: make lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     - name: setupGo
       uses: actions/setup-go@v5
       with:
-        go-version: '=1.21.8'
+        go-version: '=1.22.8'
     - name: Docker login ghcr.io
       uses: docker/login-action@v3
       with:
@@ -62,7 +62,7 @@ jobs:
     - name: setupGo
       uses: actions/setup-go@v5
       with:
-        go-version: '=1.21.8'
+        go-version: '=1.22.8'
     - name: Update manifests
       run: |
         make release RELEASE_TAG=${{ env.TAG }} REGISTRY=${{ env.GHCR_REGISTRY }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 # Options for analysis running.
 run:
-  go: "1.21"
+  go: "1.22"
   skip-files:
     - "zz_generated.*\\.go$"
     - "conversion\\.go"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,15 +16,6 @@ ARG goproxy=https://proxy.golang.org
 # Run this with docker build --build-arg package=./controlplane or --build-arg package=./bootstrap
 ENV GOPROXY=$goproxy
 
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-
-# Cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN --mount=type=cache,target=/go/pkg/mod \
-    go mod download
-
 # Copy the sources
 COPY ./ ./
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ SHELL = /usr/bin/env bash -o pipefail
 #
 # Go.
 #
-GO_VERSION ?= 1.22.0
+GO_VERSION ?= 1.22.8
 GO_CONTAINER_IMAGE ?= docker.io/library/golang:$(GO_VERSION)
 
 # Use GOPROXY environment variable if set

--- a/Makefile
+++ b/Makefile
@@ -113,8 +113,8 @@ GH := $(abspath $(TOOLS_BIN_DIR)/$(GH_BIN))
 # Registry / images
 TAG ?= dev
 ARCH ?= $(shell go env GOARCH)
-ALL_ARCH = amd64 arm arm64 ppc64le s390x
-TARGET_PLATFORMS := linux/amd64,linux/arm64,linux/arm,linux/ppc64le,linux/s390x
+ALL_ARCH = amd64 arm64
+TARGET_PLATFORMS := linux/amd64,linux/arm64
 MACHINE := cluster-api-provider-rke2
 REGISTRY ?= ghcr.io
 ORG ?= rancher

--- a/examples/docker/air-gapped/image-building/files/install.sh
+++ b/examples/docker/air-gapped/image-building/files/install.sh
@@ -165,10 +165,6 @@ setup_arch() {
         ARCH=amd64
         SUFFIX=$(uname -s | tr '[:upper:]' '[:lower:]')-${ARCH}
         ;;
-    s390x)
-        ARCH=s390x
-        SUFFIX=$(uname -s | tr '[:upper:]' '[:lower:]')-${ARCH}
-        ;;
     *)
         fatal "unsupported architecture ${ARCH}"
         ;;

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/cluster-api-provider-rke2
 
-go 1.21
+go 1.22
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/cluster-api-provider-rke2/hack/tools
 
-go 1.22.6
+go 1.22.8
 
 require sigs.k8s.io/cluster-api/hack/tools v0.0.0-20240820112706-3abe3058a6a8
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Support only amd64/armd64 archs and publish images to speed up the image building process. We might consider adding other archs in the future based on the need and demand from the users.

To further speed up build process, this patch removes redundant steps from Dockerfile. The mod-related steps are redundant because go build handles downloading dependencies as needed already and the existing build step is already configured to cache them, so there shouldn't be any meaningful difference in build times when dependencies are added/updated.

Last, we bump go version to v1.22.x to keep it more or less newer.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
