### PR TITLE
ci: Check for broken links in MD files

### DIFF
--- a/.github/workflows/pr-md-link-check.yml
+++ b/.github/workflows/pr-md-link-check.yml
@@ -1,0 +1,16 @@
+name: PR check Markdown links
+
+on: [pull_request, workflow_dispatch]
+  
+# Remove all permissions from GITHUB_TOKEN except metadata.
+permissions: {}
+
+jobs:
+  markdown-link-check:
+    name: Broken Links
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: |
+        npm install -g markdown-link-check@3.12.2
+        find . -name \*.md -print0 | xargs -0 -n1 markdown-link-check --quiet --config .markdown-link-check.json

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,0 +1,7 @@
+{
+    "ignorePatterns": [
+        {
+          "pattern": "^http://localhost:3000/$"
+        }
+      ]
+}

--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ Please see our [book](https://rancher.github.io/cluster-api-provider-rke2/) for 
 
 ## How to contribute?
 
-See our [contributor guide](https://rancher.github.io/cluster-api-provider-rke2/03_developer/00.html) for more details on how to get involved.
+See our [contributor guide](https://rancher.github.io/cluster-api-provider-rke2/04_developer/00.html) for more details on how to get involved.

--- a/docs/book/src/03_examples/01_aws.md
+++ b/docs/book/src/03_examples/01_aws.md
@@ -14,7 +14,7 @@ clusterctl init --bootstrap rke2 --control-plane rke2 --infrastructure aws
 
 ## Create a workload cluster
 
-Before creating a workload clusters, it is required to build an AMI for the RKE2 version that is going to be installed on the cluster. You can follow the steps in the [image-builder README](../../image-builder/README.md#aws) to build the AMI.
+Before creating a workload clusters, it is required to build an AMI for the RKE2 version that is going to be installed on the cluster. You can follow the steps in the [image-builder README](https://github.com/rancher/cluster-api-provider-rke2/tree/main/image-builder#aws) to build the AMI.
 
 You will need to set the following environment variables:
 

--- a/docs/old/RKE2 Cluster API Provider - Data Type definitions.md
+++ b/docs/old/RKE2 Cluster API Provider - Data Type definitions.md
@@ -12,11 +12,11 @@ Therefore a particular attention has to be given to the kinds of manifests the e
 
 RKE2 is a very configurable Kubernetes distribution. The main ways to configure RKE2 are as follows:
 
-- config.yaml file (default location at /etc/rancher/rke2/): configuration options for RKE2 that are described in this [documentation page]([Server Configuration Reference - RKE2 - Rancher's Next Generation Kubernetes Distribution](https://docs.rke2.io/install/install_options/server_config/))
+- config.yaml file (default location at /etc/rancher/rke2/): configuration options for RKE2 that are described in this [documentation page]([Server Configuration Reference - RKE2 - Rancher's Next Generation Kubernetes Distribution](https://docs.rke2.io/reference/server_config))
   
 - registries.yaml (default location at /etc/rancher/rke2/): Container Image registry configuration for the cluster (mirrors, rewrites, etc.), documentation available in this [RKE2 Documentation page](https://docs.rke2.io/install/containerd_registry_configuration)
   
-- Environement variables for versions, etc. (options documented [here]([Overview - RKE2 - Rancher's Next Generation Kubernetes Distribution](https://docs.rke2.io/install/install_options/install_options/#configuring-the-linux-installation-script)))
+- Environment variables for versions, etc. (options documented [here]([Overview - RKE2 - Rancher's Next Generation Kubernetes Distribution](https://docs.rke2.io/install/configuration#configuring-the-linux-installation-script)))
   
 - Possibly automatically deploy manifests in `/var/lib/rancher/rke2/server/manifests/`
   


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This PR adds a CI workflow that checks for broken links in MD files. The workflow is currently configured to run on each PR as well as manually (mostly to be able to test it once merged).

Upstream CAPI workflows use a 3rd party [action](https://github.com/gaurav-nelson/github-action-markdown-link-check) to achieve the same, which we could use but it will require approval by RST to be able to run it in this repo. And since this action [is no longer supported](https://github.com/gaurav-nelson/github-action-markdown-link-check?tab=readme-ov-file#--update-may-2024-), I thought it would be best to invoke the [tool](https://github.com/tcort/markdown-link-check) that the 3rd party action is using under the hood.

**Which issue(s) this PR fixes**:
Fixes #493 

**Special notes for your reviewer**:

You can view results from previous CI runs in https://github.com/rancher/cluster-api-provider-rke2/actions/workflows/pr-md-link-check.yml

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
