### PR TITLE
gzip cloud-init userdata

### DIFF
--- a/bootstrap/internal/cloudinit/cloudinit.go
+++ b/bootstrap/internal/cloudinit/cloudinit.go
@@ -19,6 +19,7 @@ package cloudinit
 
 import (
 	"bytes"
+	"compress/gzip"
 	"fmt"
 	"strings"
 	"text/template"
@@ -135,12 +136,12 @@ func generate(kind string, tpl string, data interface{}) ([]byte, error) {
 		return nil, errors.Wrapf(err, "failed to parse %s template", kind)
 	}
 
-	var out bytes.Buffer
-	if err := t.Execute(&out, data); err != nil {
+	var buf bytes.Buffer
+	out := gzip.NewWriter(&buf)
+	if err := t.Execute(out, data); err != nil {
 		return nil, errors.Wrapf(err, "failed to generate %s template", kind)
 	}
-
-	return out.Bytes(), nil
+	return buf.Bytes(), nil
 }
 
 func cleanupAdditionalCloudInit(cloudInitData string) (string, error) {


### PR DESCRIPTION
<!--
kind/bug
-->

**What this PR does / why we need it**:

Gzips cloud-init userdata, which avoids size limits imposed by various providers (e.g. AWS EC2 16k bytes userdata limit).

This is a fairly simple change which works in my testing but I'm looking for feedback on tests, etc. to add. I'm also not sure where to add docs, though I'm happy to do so.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #510

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
