### PR TITLE
Rotate kubeconfig before it expires

### DIFF
--- a/controlplane/internal/controllers/rke2controlplane_controller.go
+++ b/controlplane/internal/controllers/rke2controlplane_controller.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"sigs.k8s.io/cluster-api/util/certs"
 	"strings"
 	"time"
 
@@ -50,8 +49,10 @@ import (
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
+	"sigs.k8s.io/cluster-api/util/certs"
 	"sigs.k8s.io/cluster-api/util/collections"
 	"sigs.k8s.io/cluster-api/util/conditions"
+	capikubeconfig "sigs.k8s.io/cluster-api/util/kubeconfig"
 	"sigs.k8s.io/cluster-api/util/patch"
 
 	controlplanev1 "github.com/rancher/cluster-api-provider-rke2/controlplane/api/v1beta1"
@@ -59,7 +60,6 @@ import (
 	"github.com/rancher/cluster-api-provider-rke2/pkg/registration"
 	"github.com/rancher/cluster-api-provider-rke2/pkg/rke2"
 	"github.com/rancher/cluster-api-provider-rke2/pkg/secret"
-	capikubeconfig "sigs.k8s.io/cluster-api/util/kubeconfig"
 )
 
 const (
@@ -826,8 +826,8 @@ func (r *RKE2ControlPlaneReconciler) reconcileKubeconfig(
 
 	if needsRotation {
 		logger.Info("Rotating kubeconfig secret")
-		err = kubeconfig.CreateSecretWithOwner(ctx, r.Client, clusterName, endpoint.String(), controllerOwnerRef)
-		if err != nil {
+
+		if err := kubeconfig.CreateSecretWithOwner(ctx, r.Client, clusterName, endpoint.String(), controllerOwnerRef); err != nil {
 			return ctrl.Result{}, errors.Wrap(err, "failed to regenerate kubeconfig")
 		}
 	}


### PR DESCRIPTION
<!--
kind/bug
-->

**What this PR does / why we need it**:

Recreates the kubeconfig after half of the expiration period (1 year, renews 6 months). See similar code in kubeadm control plane [here](https://github.com/kubernetes-sigs/cluster-api/blob/92e16dbdaead4dd3e1f9ebec2c0d395733d63d5f/controlplane/kubeadm/internal/controllers/helpers.go#L98)

**Which issue(s) this PR fixes**

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
