### PR TITLE
Bump envtest to 1.32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ export GO111MODULE=on
 #
 # Kubebuilder.
 #
-export KUBEBUILDER_ENVTEST_KUBERNETES_VERSION ?= 1.25.0
+export KUBEBUILDER_ENVTEST_KUBERNETES_VERSION ?= 1.32.0
 export KUBEBUILDER_CONTROLPLANE_START_TIMEOUT ?= 60s
 export KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT ?= 60s
 
@@ -71,7 +71,7 @@ KUSTOMIZE_PKG := sigs.k8s.io/kustomize/kustomize/v4
 # Intentionally using a commit from main to use a setup-envtest version
 # that uses binaries from controller-tools, not GCS.
 # CR PR: https://github.com/kubernetes-sigs/controller-runtime/pull/2811
-SETUP_ENVTEST_VER := v0.0.0-20240522175850-2e9781e9fc60
+SETUP_ENVTEST_VER := release-0.19
 SETUP_ENVTEST_BIN := setup-envtest
 SETUP_ENVTEST := $(abspath $(TOOLS_BIN_DIR)/$(SETUP_ENVTEST_BIN)-$(SETUP_ENVTEST_VER))
 SETUP_ENVTEST_PKG := sigs.k8s.io/controller-runtime/tools/setup-envtest

--- a/controlplane/internal/controllers/rke2controlplane_controller_test.go
+++ b/controlplane/internal/controllers/rke2controlplane_controller_test.go
@@ -1,6 +1,8 @@
 package controllers
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	bootstrapv1 "github.com/rancher/cluster-api-provider-rke2/bootstrap/api/v1beta1"
@@ -17,7 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Reconclie control plane conditions", func() {
+var _ = Describe("Reconcile control plane conditions", func() {
 	var (
 		err            error
 		cp             *rke2.ControlPlane
@@ -135,7 +137,9 @@ var _ = Describe("Reconclie control plane conditions", func() {
 			},
 		}
 		Expect(testEnv.Create(ctx, nodeByRef.DeepCopy())).To(Succeed())
-		Eventually(testEnv.Get(ctx, client.ObjectKeyFromObject(nodeByRef), nodeByRef)).Should(Succeed())
+		Eventually(func() error {
+			return testEnv.Get(ctx, client.ObjectKeyFromObject(nodeByRef), nodeByRef)
+		}, 5*time.Second).Should(Succeed())
 		Expect(testEnv.Status().Update(ctx, nodeByRef.DeepCopy())).To(Succeed())
 
 		orphanedNode = &corev1.Node{ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Bumping envtest to v1.32 and setting a timeout in one test case prevents flakes we see in CI

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/rancher/cluster-api-provider-rke2/issues/417

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
