### PR TITLE
Bump kustomize to v5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,10 +62,10 @@ endif
 GO_INSTALL := ./scripts/go-install.sh
 
 # Binaries
-KUSTOMIZE_VER := v4.5.2
+KUSTOMIZE_VER := v5.5.0
 KUSTOMIZE_BIN := kustomize
 KUSTOMIZE := $(abspath $(TOOLS_BIN_DIR)/$(KUSTOMIZE_BIN)-$(KUSTOMIZE_VER))
-KUSTOMIZE_PKG := sigs.k8s.io/kustomize/kustomize/v4
+KUSTOMIZE_PKG := sigs.k8s.io/kustomize/kustomize/v5
 
 # This is a commit from CR main (22.05.2024).
 # Intentionally using a commit from main to use a setup-envtest version

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ GOLANGCI_LINT_VER := v1.55.1
 GOLANGCI_LINT_BIN := golangci-lint
 GOLANGCI_LINT := $(abspath $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN))
 
-GINKGO_VER := v2.20.1
+GINKGO_VER := v2.22.0
 GINKGO_BIN := ginkgo
 GINKGO := $(abspath $(TOOLS_BIN_DIR)/$(GINKGO_BIN)-$(GINKGO_VER))
 GINKGO_PKG := github.com/onsi/ginkgo/v2/ginkgo

--- a/bootstrap/config/certmanager/certificate.yaml
+++ b/bootstrap/config/certmanager/certificate.yaml
@@ -15,14 +15,14 @@ metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
   namespace: system
 spec:
-  # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
+  # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
   dnsNames:
-  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
-  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
-  secretName: $(SERVICE_NAME)-cert # this secret will not be prefixed, since it's not managed by kustomize
+  secretName: rke2-bootstrap-webhook-service-cert # this secret will not be prefixed, since it's not managed by kustomize
   subject:
     organizations:
       - Rancher by SUSE

--- a/bootstrap/config/certmanager/kustomizeconfig.yaml
+++ b/bootstrap/config/certmanager/kustomizeconfig.yaml
@@ -6,14 +6,3 @@ nameReference:
   - kind: Certificate
     group: cert-manager.io
     path: spec/issuerRef/name
-
-varReference:
-- kind: Certificate
-  group: cert-manager.io
-  path: spec/commonName
-- kind: Certificate
-  group: cert-manager.io
-  path: spec/dnsNames
-- kind: Certificate
-  group: cert-manager.io
-  path: spec/secretName

--- a/bootstrap/config/crd/kustomization.yaml
+++ b/bootstrap/config/crd/kustomization.yaml
@@ -1,5 +1,7 @@
-commonLabels:
-  cluster.x-k8s.io/v1beta1: v1alpha1_v1beta1
+labels:
+- includeSelectors: true
+  pairs:
+    cluster.x-k8s.io/v1beta1: v1alpha1_v1beta1
 
 # This kustomization.yaml is not intended to be run by itself,
 # since it depends on service name and namespace that are out of this kustomize package.
@@ -9,19 +11,17 @@ resources:
 - bases/bootstrap.cluster.x-k8s.io_rke2configtemplates.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-- patches/webhook_in_rke2configs.yaml
-- patches/webhook_in_rke2configtemplates.yaml
-#- patches/webhook_in_rke2configtemplates.yaml
+- path: patches/webhook_in_rke2configs.yaml
+- path: patches/webhook_in_rke2configtemplates.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-- patches/cainjection_in_rke2configs.yaml
-- patches/cainjection_in_rke2configtemplates.yaml
-#- patches/cainjection_in_rke2configtemplates.yaml
+- path: patches/cainjection_in_rke2configs.yaml
+- path: patches/cainjection_in_rke2configtemplates.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/bootstrap/config/crd/kustomizeconfig.yaml
+++ b/bootstrap/config/crd/kustomizeconfig.yaml
@@ -14,6 +14,3 @@ namespace:
   group: apiextensions.k8s.io
   path: spec/conversion/webhook/clientConfig/service/namespace
   create: false
-
-varReference:
-- path: metadata/annotations

--- a/bootstrap/config/crd/patches/cainjection_in_rke2configs.yaml
+++ b/bootstrap/config/crd/patches/cainjection_in_rke2configs.yaml
@@ -3,5 +3,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: rke2configs.bootstrap.cluster.x-k8s.io

--- a/bootstrap/config/crd/patches/cainjection_in_rke2configtemplates.yaml
+++ b/bootstrap/config/crd/patches/cainjection_in_rke2configtemplates.yaml
@@ -3,5 +3,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: rke2configtemplates.bootstrap.cluster.x-k8s.io

--- a/bootstrap/config/crd/patches/webhook_in_rke2configs.yaml
+++ b/bootstrap/config/crd/patches/webhook_in_rke2configs.yaml
@@ -10,7 +10,7 @@ spec:
       clientConfig:
         service:
           namespace: system
-          name: webhook-service
+          name: rke2-bootstrap-webhook-service
           path: /convert
       conversionReviewVersions:
       - v1

--- a/bootstrap/config/default/kustomization.yaml
+++ b/bootstrap/config/default/kustomization.yaml
@@ -9,53 +9,122 @@ namespace: rke2-bootstrap-system
 namePrefix: rke2-bootstrap-
 
 # Labels to add to all resources and selectors.
-commonLabels:
-  cluster.x-k8s.io/provider: "bootstrap-rke2"
+labels:
+- includeSelectors: true
+  pairs:
+    cluster.x-k8s.io/provider: bootstrap-rke2
 
 resources:
 - namespace.yaml
-
-bases:
 - ../crd
 - ../rbac
 - ../manager
 - ../webhook
 - ../certmanager
 
-patchesStrategicMerge:
-  - manager_image_patch.yaml
-  - manager_pull_policy.yaml
-  - manager_webhook_patch.yaml
-  - webhookcainjection_patch.yaml
+patches:
+# Provide customizable hook for make targets.
+- path: manager_image_patch.yaml
+- path: manager_pull_policy.yaml
+# Enable webhook.
+- path: manager_webhook_patch.yaml
+# Inject certificate in the webhook definition.
+- path: webhookcainjection_patch.yaml
 
-# the following config is for teaching kustomize how to do var substitution
-vars:
-  - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-    objref:
-      kind: Certificate
-      group: cert-manager.io
-      version: v1
-      name: serving-cert # this name should match the one in certificate.yaml
-    fieldref:
-      fieldpath: metadata.namespace
-  - name: CERTIFICATE_NAME
-    objref:
-      kind: Certificate
-      group: cert-manager.io
-      version: v1
-      name: serving-cert # this name should match the one in certificate.yaml
-  - name: SERVICE_NAMESPACE # namespace of the service
-    objref:
-      kind: Service
-      version: v1
-      name: webhook-service
-    fieldref:
-      fieldpath: metadata.namespace
-  - name: SERVICE_NAME
-    objref:
-      kind: Service
-      version: v1
-      name: webhook-service
-
-configurations:
-  - kustomizeconfig.yaml
+replacements:
+- source: # Add cert-manager annotation to ValidatingWebhookConfiguration, MutatingWebhookConfiguration and CRDs
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+    fieldPath: .metadata.namespace # namespace of the certificate CR
+  targets:
+    - select:
+        kind: ValidatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 0
+        create: true
+    - select:
+        kind: MutatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 0
+        create: true
+    - select:
+        kind: CustomResourceDefinition
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 0
+        create: true
+- source:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+    fieldPath: .metadata.name
+  targets:
+    - select:
+        kind: ValidatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 1
+        create: true
+    - select:
+        kind: MutatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 1
+        create: true
+    - select:
+        kind: CustomResourceDefinition
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 1
+        create: true
+- source: # Add cert-manager annotation to the webhook Service
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.name # namespace of the service
+  targets:
+    - select:
+        kind: Certificate
+        group: cert-manager.io
+        version: v1
+      fieldPaths:
+        - .spec.dnsNames.0
+        - .spec.dnsNames.1
+      options:
+        delimiter: '.'
+        index: 0
+        create: true
+- source:
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.namespace # namespace of the service
+  targets:
+    - select:
+        kind: Certificate
+        group: cert-manager.io
+        version: v1
+      fieldPaths:
+        - .spec.dnsNames.0
+        - .spec.dnsNames.1
+      options:
+        delimiter: '.'
+        index: 1
+        create: true

--- a/bootstrap/config/default/kustomizeconfig.yaml
+++ b/bootstrap/config/default/kustomizeconfig.yaml
@@ -1,3 +1,0 @@
-varReference:
-- kind: Deployment
-  path: spec/template/spec/volumes/secret/secretName

--- a/bootstrap/config/default/manager_webhook_patch.yaml
+++ b/bootstrap/config/default/manager_webhook_patch.yaml
@@ -19,4 +19,4 @@ spec:
       volumes:
       - name: cert
         secret:
-          secretName: $(SERVICE_NAME)-cert
+          secretName: rke2-bootstrap-webhook-service-cert

--- a/bootstrap/config/default/webhookcainjection_patch.yaml
+++ b/bootstrap/config/default/webhookcainjection_patch.yaml
@@ -5,11 +5,11 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME

--- a/bootstrap/config/webhook/kustomizeconfig.yaml
+++ b/bootstrap/config/webhook/kustomizeconfig.yaml
@@ -20,6 +20,3 @@ namespace:
   group: admissionregistration.k8s.io
   path: webhooks/clientConfig/service/namespace
   create: true
-
-varReference:
-- path: metadata/annotations

--- a/controlplane/config/certmanager/certificate.yaml
+++ b/controlplane/config/certmanager/certificate.yaml
@@ -15,14 +15,14 @@ metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
   namespace: system
 spec:
-  # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
+  # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
   dnsNames:
-  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
-  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
-  secretName: $(SERVICE_NAME)-cert # this secret will not be prefixed, since it's not managed by kustomize
+  secretName: rke2-controlplane-webhook-service-cert # this secret will not be prefixed, since it's not managed by kustomize
   subject:
     organizations:
       - Rancher by SUSE

--- a/controlplane/config/certmanager/kustomizeconfig.yaml
+++ b/controlplane/config/certmanager/kustomizeconfig.yaml
@@ -6,14 +6,3 @@ nameReference:
   - kind: Certificate
     group: cert-manager.io
     path: spec/issuerRef/name
-
-varReference:
-- kind: Certificate
-  group: cert-manager.io
-  path: spec/commonName
-- kind: Certificate
-  group: cert-manager.io
-  path: spec/dnsNames
-- kind: Certificate
-  group: cert-manager.io
-  path: spec/secretName

--- a/controlplane/config/crd/kustomization.yaml
+++ b/controlplane/config/crd/kustomization.yaml
@@ -1,5 +1,7 @@
-commonLabels:
-  cluster.x-k8s.io/v1beta1: v1alpha1_v1beta1
+labels:
+- includeSelectors: true
+  pairs:
+    cluster.x-k8s.io/v1beta1: v1alpha1_v1beta1
 
 # This kustomization.yaml is not intended to be run by itself,
 # since it depends on service name and namespace that are out of this kustomize package.
@@ -9,17 +11,17 @@ resources:
 - bases/controlplane.cluster.x-k8s.io_rke2controlplanetemplates.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-- patches/webhook_in_rke2controlplanes.yaml
-- patches/webhook_in_rke2controlplanetemplates.yaml
+- path: patches/webhook_in_rke2controlplanes.yaml
+- path: patches/webhook_in_rke2controlplanetemplates.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-- patches/cainjection_in_rke2controlplanes.yaml
-- patches/cainjection_in_rke2controlplanetemplates.yaml
+- path: patches/cainjection_in_rke2controlplanes.yaml
+- path: patches/cainjection_in_rke2controlplanetemplates.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/controlplane/config/crd/kustomizeconfig.yaml
+++ b/controlplane/config/crd/kustomizeconfig.yaml
@@ -14,6 +14,3 @@ namespace:
   group: apiextensions.k8s.io
   path: spec/conversion/webhook/clientConfig/service/namespace
   create: false
-
-varReference:
-- path: metadata/annotations

--- a/controlplane/config/crd/patches/cainjection_in_rke2controlplanes.yaml
+++ b/controlplane/config/crd/patches/cainjection_in_rke2controlplanes.yaml
@@ -3,5 +3,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: rke2controlplanes.controlplane.cluster.x-k8s.io

--- a/controlplane/config/crd/patches/cainjection_in_rke2controlplanetemplates.yaml
+++ b/controlplane/config/crd/patches/cainjection_in_rke2controlplanetemplates.yaml
@@ -3,5 +3,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: rke2controlplanetemplates.controlplane.cluster.x-k8s.io

--- a/controlplane/config/default/kustomization.yaml
+++ b/controlplane/config/default/kustomization.yaml
@@ -9,54 +9,120 @@ namespace: rke2-control-plane-system
 namePrefix: rke2-control-plane-
 
 # Labels to add to all resources and selectors.
-commonLabels:
-  cluster.x-k8s.io/provider: "control-plane-rke2"
+labels:
+- includeSelectors: true
+  pairs:
+    cluster.x-k8s.io/provider: control-plane-rke2
 
 resources:
 - namespace.yaml
-
-bases:
 - ../crd
 - ../rbac
 - ../manager
 - ../webhook
 - ../certmanager
 
-patchesStrategicMerge:
-  - manager_image_patch.yaml
-  - manager_pull_policy.yaml
-  - manager_webhook_patch.yaml
-  - webhookcainjection_patch.yaml
-  - manager_role_aggregation_patch.yaml
+patches:
+# Provide customizable hook for make targets.
+- path: manager_image_patch.yaml
+- path: manager_pull_policy.yaml
+# Enable webhook.
+- path: manager_webhook_patch.yaml
+# Inject certificate in the webhook definition.
+- path: webhookcainjection_patch.yaml
+# Enable aggregated ClusterRole aggregation
+- path: manager_role_aggregation_patch.yaml
 
-# the following config is for teaching kustomize how to do var substitution
-vars:
-  - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-    objref:
-      kind: Certificate
+replacements:
+- source:
+    fieldPath: .metadata.namespace
+    group: cert-manager.io
+    kind: Certificate
+    name: serving-cert
+    version: v1
+  targets:
+  - fieldPaths:
+    - .metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      create: true
+      delimiter: /
+    select:
+      kind: ValidatingWebhookConfiguration
+  - fieldPaths:
+    - .metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      create: true
+      delimiter: /
+    select:
+      kind: MutatingWebhookConfiguration
+  - fieldPaths:
+    - .metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      create: true
+      delimiter: /
+    select:
+      kind: CustomResourceDefinition
+- source:
+    fieldPath: .metadata.name
+    group: cert-manager.io
+    kind: Certificate
+    name: serving-cert
+    version: v1
+  targets:
+  - fieldPaths:
+    - .metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      create: true
+      delimiter: /
+      index: 1
+    select:
+      kind: ValidatingWebhookConfiguration
+  - fieldPaths:
+    - .metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      create: true
+      delimiter: /
+      index: 1
+    select:
+      kind: MutatingWebhookConfiguration
+  - fieldPaths:
+    - .metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      create: true
+      delimiter: /
+      index: 1
+    select:
+      kind: CustomResourceDefinition
+- source:
+    fieldPath: .metadata.name
+    kind: Service
+    name: webhook-service
+    version: v1
+  targets:
+  - fieldPaths:
+    - .spec.dnsNames.0
+    - .spec.dnsNames.1
+    options:
+      create: true
+      delimiter: .
+    select:
       group: cert-manager.io
-      version: v1
-      name: serving-cert # this name should match the one in certificate.yaml
-    fieldref:
-      fieldpath: metadata.namespace
-  - name: CERTIFICATE_NAME
-    objref:
       kind: Certificate
+      version: v1
+- source:
+    fieldPath: .metadata.namespace
+    kind: Service
+    name: webhook-service
+    version: v1
+  targets:
+  - fieldPaths:
+    - .spec.dnsNames.0
+    - .spec.dnsNames.1
+    options:
+      create: true
+      delimiter: .
+      index: 1
+    select:
       group: cert-manager.io
+      kind: Certificate
       version: v1
-      name: serving-cert # this name should match the one in certificate.yaml
-  - name: SERVICE_NAMESPACE # namespace of the service
-    objref:
-      kind: Service
-      version: v1
-      name: webhook-service
-    fieldref:
-      fieldpath: metadata.namespace
-  - name: SERVICE_NAME
-    objref:
-      kind: Service
-      version: v1
-      name: webhook-service
-
-configurations:
-  - kustomizeconfig.yaml

--- a/controlplane/config/default/kustomizeconfig.yaml
+++ b/controlplane/config/default/kustomizeconfig.yaml
@@ -1,4 +1,0 @@
-# This configuration is for teaching kustomize how to update name ref and var substitution
-varReference:
-- kind: Deployment
-  path: spec/template/spec/volumes/secret/secretName

--- a/controlplane/config/default/manager_webhook_patch.yaml
+++ b/controlplane/config/default/manager_webhook_patch.yaml
@@ -19,4 +19,4 @@ spec:
       volumes:
       - name: cert
         secret:
-          secretName: $(SERVICE_NAME)-cert
+          secretName: rke2-controlplane-webhook-service-cert

--- a/controlplane/config/default/webhookcainjection_patch.yaml
+++ b/controlplane/config/default/webhookcainjection_patch.yaml
@@ -1,15 +1,15 @@
 # This patch add annotation to admission webhook config and
-# the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
+# the variables CERTIFICATE_NAMESPACE and CERTIFICATE_NAME will be substituted by kustomize.
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME

--- a/controlplane/config/webhook/kustomizeconfig.yaml
+++ b/controlplane/config/webhook/kustomizeconfig.yaml
@@ -20,6 +20,3 @@ namespace:
   group: admissionregistration.k8s.io
   path: webhooks/clientConfig/service/namespace
   create: true
-
-varReference:
-- path: metadata/annotations


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps kustomize to v5 and removes deprecated syntax of Kustomize:

- patchesStrategicMerge -> patches
- vars and varReference -> replacements
- bases -> resources

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #406 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
