### PR TITLE
feat: add dockerfile cross-compilation for multi-platform images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG builder_image
 # It's an invalid finding since the image is explicitly set in the Makefile.
 # https://github.com/hadolint/hadolint/wiki/DL3006
 # hadolint ignore=DL3006
-FROM ${builder_image} as builder
+FROM --platform=$BUILDPLATFORM ${builder_image} as builder
 WORKDIR /workspace
 
 # Run this with docker build --build-arg goproxy=$(go env GOPROXY) to override the goproxy
@@ -22,10 +22,11 @@ COPY ./ ./
 # Build
 ARG package=.
 ARG ldflags
+ARG TARGETOS TARGETARCH
 
 # Do not force rebuild of up-to-date packages (do not use -a) and use the compiler cache folder
 RUN --mount=type=cache,target=/go/pkg/mod \
-    CGO_ENABLED=0 GOOS=linux \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
     go build -trimpath -ldflags "${ldflags} -extldflags '-static'" \
     -o manager ${package}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

After adding cross-compilation for image building to other projects, we have experienced an optimized, faster build process and we can use the same principle to create the provider's multi-architecture images.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
