### PR TITLE
Propagate cloud provider config

### DIFF
--- a/pkg/rke2/config.go
+++ b/pkg/rke2/config.go
@@ -557,11 +557,13 @@ func GenerateInitControlPlaneConfig(opts ServerConfigOpts) (*ServerConfig, []boo
 	}
 
 	rke2AgentConfig, agentFiles, err := newRKE2AgentConfig(AgentConfigOpts{
-		AgentConfig: opts.AgentConfig,
-		Client:      opts.Client,
-		Ctx:         opts.Ctx,
-		Token:       opts.Token,
-		Version:     opts.Version,
+		AgentConfig:            opts.AgentConfig,
+		Client:                 opts.Client,
+		Ctx:                    opts.Ctx,
+		Token:                  opts.Token,
+		Version:                opts.Version,
+		CloudProviderConfigMap: opts.ServerConfig.CloudProviderConfigMap,
+		CloudProviderName:      opts.ServerConfig.CloudProviderName,
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to generate rke2 agent config: %w", err)
@@ -588,12 +590,14 @@ func GenerateJoinControlPlaneConfig(opts ServerConfigOpts) (*ServerConfig, []boo
 	}
 
 	rke2AgentConfig, agentFiles, err := newRKE2AgentConfig(AgentConfigOpts{
-		AgentConfig: opts.AgentConfig,
-		Client:      opts.Client,
-		Ctx:         opts.Ctx,
-		ServerURL:   opts.ServerURL,
-		Token:       opts.Token,
-		Version:     opts.Version,
+		AgentConfig:            opts.AgentConfig,
+		Client:                 opts.Client,
+		Ctx:                    opts.Ctx,
+		ServerURL:              opts.ServerURL,
+		Token:                  opts.Token,
+		Version:                opts.Version,
+		CloudProviderConfigMap: opts.ServerConfig.CloudProviderConfigMap,
+		CloudProviderName:      opts.ServerConfig.CloudProviderName,
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to generate rke2 agent config: %w", err)


### PR DESCRIPTION
kind/bug

**What this PR does / why we need it**:

This fixes the absence of the `cloud-provider-name` in the generated `/etc/rancher/rke2/config.yaml`

Consider this an hotfix. Due to the nature of the code, it seems to generate duplicate files. It's safe to ignore. 
A proper fix would probably need refactoring of the entire bootstrap generation logic to make it more maintainable and understandable.

For example: 

```json
          {
              Path: "/etc/rancher/rke2/audit-policy.yaml",
              Owner: "root:root",
              Permissions: "0644",
              Encoding: "",
              Content: "test_audit",
              ContentFrom: nil,
          },
          {
              Path: "/etc/rancher/rke2/cloud-provider-config",
              Owner: "root:root",
              Permissions: "0644",
              Encoding: "",
              Content: "test_cloud_config",
              ContentFrom: nil,
          },
          {
              Path: "/etc/rancher/rke2/etcd-s3-ca.crt",
              Owner: "root:root",
              Permissions: "0640",
              Encoding: "",
              Content: "test_ca",
              ContentFrom: nil,
          },
          {
              Path: "/etc/rancher/rke2/cloud-provider-config",
              Owner: "root:root",
              Permissions: "0644",
              Encoding: "",
              Content: "test_cloud_config",
              ContentFrom: nil,
          },

```

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #567

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
