### PR TITLE
🌱 Bump controller-runtime to 0.20.1 and related changes

### DIFF
--- a/bootstrap/api/v1beta1/rke2config_webhook.go
+++ b/bootstrap/api/v1beta1/rke2config_webhook.go
@@ -38,20 +38,35 @@ var (
 	rke2configlog         = logf.Log.WithName("rke2config-resource")
 )
 
-// SetupWebhookWithManager sets up and registers the webhook with the manager.
-func (r *RKE2Config) SetupWebhookWithManager(mgr ctrl.Manager) error {
+// RKE2ConfigCustomDefaulter struct is responsible for setting default values on the custom resource of the
+// Kind RKE2Config when those are created or updated.
+type RKE2ConfigCustomDefaulter struct{}
+
+// RKE2ConfigCustomValidator struct is responsible for validating the RKE2Config resource
+// when it is created, updated, or deleted.
+type RKE2ConfigCustomValidator struct{}
+
+// SetupRKE2ConfigWebhookWithManager sets up the Controller Manager for the Webhook for the RKE2ControlPlaneTemplate resource.
+func SetupRKE2ConfigWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(&RKE2Config{}).
+		WithValidator(&RKE2ConfigCustomValidator{}).
+		WithDefaulter(&RKE2ConfigCustomDefaulter{}).
 		Complete()
 }
 
 //+kubebuilder:webhook:path=/mutate-bootstrap-cluster-x-k8s-io-v1beta1-rke2config,mutating=true,failurePolicy=fail,sideEffects=None,groups=bootstrap.cluster.x-k8s.io,resources=rke2configs,verbs=create;update,versions=v1beta1,name=mrke2config.kb.io,admissionReviewVersions=v1
 
-var _ webhook.CustomDefaulter = &RKE2Config{}
+var _ webhook.CustomDefaulter = &RKE2ConfigCustomDefaulter{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (r *RKE2Config) Default(_ context.Context, _ runtime.Object) error {
-	DefaultRKE2ConfigSpec(&r.Spec)
+func (r *RKE2ConfigCustomDefaulter) Default(_ context.Context, obj runtime.Object) error {
+	rc, ok := obj.(*RKE2Config)
+	if !ok {
+		return fmt.Errorf("expected a RKE2Config object but got %T", obj)
+	}
+
+	DefaultRKE2ConfigSpec(&rc.Spec)
 
 	return nil
 }
@@ -65,40 +80,50 @@ func DefaultRKE2ConfigSpec(spec *RKE2ConfigSpec) {
 
 //+kubebuilder:webhook:path=/validate-bootstrap-cluster-x-k8s-io-v1beta1-rke2config,mutating=false,failurePolicy=fail,sideEffects=None,groups=bootstrap.cluster.x-k8s.io,resources=rke2configs,verbs=create;update,versions=v1beta1,name=vrke2config.kb.io,admissionReviewVersions=v1
 
-var _ webhook.CustomValidator = &RKE2Config{}
+var _ webhook.CustomValidator = &RKE2ConfigCustomValidator{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (r *RKE2Config) ValidateCreate(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
-	rke2configlog.Info("RKE2Config validate create", "rke2config", klog.KObj(r))
+func (r *RKE2ConfigCustomValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	rc, ok := obj.(*RKE2Config)
+	if !ok {
+		return nil, fmt.Errorf("expected a RKE2Config object but got %T", obj)
+	}
+
+	rke2configlog.Info("RKE2Config validate create", "rke2config", klog.KObj(rc))
 
 	var allErrs field.ErrorList
 
-	allErrs = append(allErrs, ValidateRKE2ConfigSpec(r.Name, &r.Spec)...)
+	allErrs = append(allErrs, ValidateRKE2ConfigSpec(rc.Name, &rc.Spec)...)
 
 	if len(allErrs) == 0 {
 		return nil, nil
 	}
 
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind("RKE2Config").GroupKind(), r.Name, allErrs)
+	return nil, apierrors.NewInvalid(GroupVersion.WithKind("RKE2Config").GroupKind(), rc.Name, allErrs)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (r *RKE2Config) ValidateUpdate(_ context.Context, _, _ runtime.Object) (admission.Warnings, error) {
-	rke2configlog.Info("RKE2Config validate update", "rke2config", klog.KObj(r))
+func (r *RKE2ConfigCustomValidator) ValidateUpdate(_ context.Context, _, newObj runtime.Object) (admission.Warnings, error) {
+	newrc, ok := newObj.(*RKE2Config)
+	if !ok {
+		return nil, fmt.Errorf("expected a RKE2Config object but got %T", newObj)
+	}
+
+	rke2configlog.Info("RKE2Config validate update", "rke2config", klog.KObj(newrc))
 
 	var allErrs field.ErrorList
 
-	allErrs = append(allErrs, ValidateRKE2ConfigSpec(r.Name, &r.Spec)...)
+	allErrs = append(allErrs, ValidateRKE2ConfigSpec(newrc.Name, &newrc.Spec)...)
 
 	if len(allErrs) == 0 {
 		return nil, nil
 	}
 
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind("RKE2Config").GroupKind(), r.Name, allErrs)
+	return nil, apierrors.NewInvalid(GroupVersion.WithKind("RKE2Config").GroupKind(), newrc.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (r *RKE2Config) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+func (r *RKE2ConfigCustomValidator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 

--- a/bootstrap/api/v1beta1/rke2config_webhook.go
+++ b/bootstrap/api/v1beta1/rke2config_webhook.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/coreos/butane/config/common"
@@ -46,11 +47,13 @@ func (r *RKE2Config) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 //+kubebuilder:webhook:path=/mutate-bootstrap-cluster-x-k8s-io-v1beta1-rke2config,mutating=true,failurePolicy=fail,sideEffects=None,groups=bootstrap.cluster.x-k8s.io,resources=rke2configs,verbs=create;update,versions=v1beta1,name=mrke2config.kb.io,admissionReviewVersions=v1
 
-var _ webhook.Defaulter = &RKE2Config{}
+var _ webhook.CustomDefaulter = &RKE2Config{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (r *RKE2Config) Default() {
+func (r *RKE2Config) Default(_ context.Context, _ runtime.Object) error {
 	DefaultRKE2ConfigSpec(&r.Spec)
+
+	return nil
 }
 
 // DefaultRKE2ConfigSpec defaults the RKE2ConfigSpec.
@@ -62,10 +65,10 @@ func DefaultRKE2ConfigSpec(spec *RKE2ConfigSpec) {
 
 //+kubebuilder:webhook:path=/validate-bootstrap-cluster-x-k8s-io-v1beta1-rke2config,mutating=false,failurePolicy=fail,sideEffects=None,groups=bootstrap.cluster.x-k8s.io,resources=rke2configs,verbs=create;update,versions=v1beta1,name=vrke2config.kb.io,admissionReviewVersions=v1
 
-var _ webhook.Validator = &RKE2Config{}
+var _ webhook.CustomValidator = &RKE2Config{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (r *RKE2Config) ValidateCreate() (admission.Warnings, error) {
+func (r *RKE2Config) ValidateCreate(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	rke2configlog.Info("RKE2Config validate create", "rke2config", klog.KObj(r))
 
 	var allErrs field.ErrorList
@@ -80,7 +83,7 @@ func (r *RKE2Config) ValidateCreate() (admission.Warnings, error) {
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (r *RKE2Config) ValidateUpdate(_ runtime.Object) (admission.Warnings, error) {
+func (r *RKE2Config) ValidateUpdate(_ context.Context, _, _ runtime.Object) (admission.Warnings, error) {
 	rke2configlog.Info("RKE2Config validate update", "rke2config", klog.KObj(r))
 
 	var allErrs field.ErrorList
@@ -95,7 +98,7 @@ func (r *RKE2Config) ValidateUpdate(_ runtime.Object) (admission.Warnings, error
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (r *RKE2Config) ValidateDelete() (admission.Warnings, error) {
+func (r *RKE2Config) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 

--- a/bootstrap/api/v1beta1/rke2config_webhook.go
+++ b/bootstrap/api/v1beta1/rke2config_webhook.go
@@ -40,10 +40,16 @@ var (
 
 // RKE2ConfigCustomDefaulter struct is responsible for setting default values on the custom resource of the
 // Kind RKE2Config when those are created or updated.
+// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
+// as it is used only for temporary operations and does not need to be deeply copied.
+// +kubebuilder:object:generate=false
 type RKE2ConfigCustomDefaulter struct{}
 
 // RKE2ConfigCustomValidator struct is responsible for validating the RKE2Config resource
 // when it is created, updated, or deleted.
+// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
+// as it is used only for temporary operations and does not need to be deeply copied.
+// +kubebuilder:object:generate=false
 type RKE2ConfigCustomValidator struct{}
 
 // SetupRKE2ConfigWebhookWithManager sets up the Controller Manager for the Webhook for the RKE2ControlPlaneTemplate resource.

--- a/bootstrap/api/v1beta1/rke2config_webhook.go
+++ b/bootstrap/api/v1beta1/rke2config_webhook.go
@@ -69,7 +69,7 @@ var _ webhook.CustomDefaulter = &RKE2ConfigCustomDefaulter{}
 func (r *RKE2ConfigCustomDefaulter) Default(_ context.Context, obj runtime.Object) error {
 	rc, ok := obj.(*RKE2Config)
 	if !ok {
-		return fmt.Errorf("expected a RKE2Config object but got %T", obj)
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a RKE2Config but got a %T", obj))
 	}
 
 	DefaultRKE2ConfigSpec(&rc.Spec)

--- a/bootstrap/api/v1beta1/rke2config_webhook_test.go
+++ b/bootstrap/api/v1beta1/rke2config_webhook_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -76,7 +77,7 @@ func TestRKE2Config_ValidateCreate(t *testing.T) {
 				Spec: *tt.spec.DeepCopy(),
 			}
 
-			_, err := config.ValidateCreate()
+			_, err := config.ValidateCreate(context.Background(), config)
 
 			if tt.expectErr {
 				Expect(err).To(HaveOccurred())

--- a/bootstrap/api/v1beta1/rke2config_webhook_test.go
+++ b/bootstrap/api/v1beta1/rke2config_webhook_test.go
@@ -69,6 +69,7 @@ func TestRKE2Config_ValidateCreate(t *testing.T) {
 		},
 	}
 
+	validator := RKE2ConfigCustomValidator{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			RegisterTestingT(t)
@@ -77,7 +78,7 @@ func TestRKE2Config_ValidateCreate(t *testing.T) {
 				Spec: *tt.spec.DeepCopy(),
 			}
 
-			_, err := config.ValidateCreate(context.Background(), config)
+			_, err := validator.ValidateCreate(context.Background(), config)
 
 			if tt.expectErr {
 				Expect(err).To(HaveOccurred())

--- a/bootstrap/api/v1beta1/rke2configtemplate_webhook.go
+++ b/bootstrap/api/v1beta1/rke2configtemplate_webhook.go
@@ -32,10 +32,16 @@ var RKE2configtemplatelog = logf.Log.WithName("RKE2configtemplate-resource")
 
 // RKE2ConfigTemplateCustomDefaulter struct is responsible for setting default values on the custom resource of the
 // Kind RKE2ConfigTemplate when those are created or updated.
+// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
+// as it is used only for temporary operations and does not need to be deeply copied.
+// +kubebuilder:object:generate=false
 type RKE2ConfigTemplateCustomDefaulter struct{}
 
 // RKE2ConfigTemplateCustomValidator struct is responsible for validating the RKE2ConfigTemplate resource
 // when it is created, updated, or deleted.
+// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
+// as it is used only for temporary operations and does not need to be deeply copied.
+// +kubebuilder:object:generate=false
 type RKE2ConfigTemplateCustomValidator struct{}
 
 // SetupRKE2ConfigTemplateWebhookWithManager sets up the Controller Manager for the Webhook for the RKE2ControlPlaneTemplate resource.

--- a/bootstrap/api/v1beta1/rke2configtemplate_webhook.go
+++ b/bootstrap/api/v1beta1/rke2configtemplate_webhook.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -36,33 +38,35 @@ func (r *RKE2ConfigTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 //+kubebuilder:webhook:path=/mutate-bootstrap-cluster-x-k8s-io-v1beta1-rke2configtemplate,mutating=true,failurePolicy=fail,sideEffects=None,groups=bootstrap.cluster.x-k8s.io,resources=rke2configtemplates,verbs=create;update,versions=v1beta1,name=mrke2configtemplate.kb.io,admissionReviewVersions=v1
 
-var _ webhook.Defaulter = &RKE2ConfigTemplate{}
+var _ webhook.CustomDefaulter = &RKE2ConfigTemplate{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (r *RKE2ConfigTemplate) Default() {
+func (r *RKE2ConfigTemplate) Default(_ context.Context, _ runtime.Object) error {
 	RKE2configtemplatelog.Info("default", "name", r.Name)
+
+	return nil
 }
 
 //+kubebuilder:webhook:path=/validate-bootstrap-cluster-x-k8s-io-v1beta1-rke2configtemplate,mutating=false,failurePolicy=fail,sideEffects=None,groups=bootstrap.cluster.x-k8s.io,resources=rke2configtemplates,verbs=create;update,versions=v1beta1,name=vrke2configtemplate.kb.io,admissionReviewVersions=v1
 
-var _ webhook.Validator = &RKE2ConfigTemplate{}
+var _ webhook.CustomValidator = &RKE2ConfigTemplate{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (r *RKE2ConfigTemplate) ValidateCreate() (admission.Warnings, error) {
+func (r *RKE2ConfigTemplate) ValidateCreate(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	RKE2configtemplatelog.Info("validate create", "name", r.Name)
 
 	return nil, nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (r *RKE2ConfigTemplate) ValidateUpdate(_ runtime.Object) (admission.Warnings, error) {
+func (r *RKE2ConfigTemplate) ValidateUpdate(_ context.Context, _, _ runtime.Object) (admission.Warnings, error) {
 	RKE2configtemplatelog.Info("validate update", "name", r.Name)
 
 	return nil, nil
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (r *RKE2ConfigTemplate) ValidateDelete() (admission.Warnings, error) {
+func (r *RKE2ConfigTemplate) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	RKE2configtemplatelog.Info("validate delete", "name", r.Name)
 
 	return nil, nil

--- a/bootstrap/api/v1beta1/rke2configtemplate_webhook.go
+++ b/bootstrap/api/v1beta1/rke2configtemplate_webhook.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -61,7 +62,7 @@ var _ webhook.CustomDefaulter = &RKE2ConfigTemplateCustomDefaulter{}
 func (r *RKE2ConfigTemplateCustomDefaulter) Default(_ context.Context, obj runtime.Object) error {
 	rct, ok := obj.(*RKE2ConfigTemplate)
 	if !ok {
-		return fmt.Errorf("expected a RKE2ConfigTemplate object but got %T", obj)
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a RKE2ConfigTemplate but got a %T", obj))
 	}
 
 	RKE2configtemplatelog.Info("default", "name", rct.Name)

--- a/bootstrap/api/v1beta1/rke2configtemplate_webhook.go
+++ b/bootstrap/api/v1beta1/rke2configtemplate_webhook.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import (
 	"context"
+	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -29,45 +30,75 @@ import (
 // RKE2configtemplatelog is for logging in this package.
 var RKE2configtemplatelog = logf.Log.WithName("RKE2configtemplate-resource")
 
-// SetupWebhookWithManager sets up and registers the webhook with the manager.
-func (r *RKE2ConfigTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
+// RKE2ConfigTemplateCustomDefaulter struct is responsible for setting default values on the custom resource of the
+// Kind RKE2ConfigTemplate when those are created or updated.
+type RKE2ConfigTemplateCustomDefaulter struct{}
+
+// RKE2ConfigTemplateCustomValidator struct is responsible for validating the RKE2ConfigTemplate resource
+// when it is created, updated, or deleted.
+type RKE2ConfigTemplateCustomValidator struct{}
+
+// SetupRKE2ConfigTemplateWebhookWithManager sets up the Controller Manager for the Webhook for the RKE2ControlPlaneTemplate resource.
+func SetupRKE2ConfigTemplateWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(&RKE2ConfigTemplate{}).
+		WithValidator(&RKE2ConfigTemplateCustomValidator{}).
+		WithDefaulter(&RKE2ConfigTemplateCustomDefaulter{}).
 		Complete()
 }
 
 //+kubebuilder:webhook:path=/mutate-bootstrap-cluster-x-k8s-io-v1beta1-rke2configtemplate,mutating=true,failurePolicy=fail,sideEffects=None,groups=bootstrap.cluster.x-k8s.io,resources=rke2configtemplates,verbs=create;update,versions=v1beta1,name=mrke2configtemplate.kb.io,admissionReviewVersions=v1
 
-var _ webhook.CustomDefaulter = &RKE2ConfigTemplate{}
+var _ webhook.CustomDefaulter = &RKE2ConfigTemplateCustomDefaulter{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (r *RKE2ConfigTemplate) Default(_ context.Context, _ runtime.Object) error {
-	RKE2configtemplatelog.Info("default", "name", r.Name)
+func (r *RKE2ConfigTemplateCustomDefaulter) Default(_ context.Context, obj runtime.Object) error {
+	rct, ok := obj.(*RKE2ConfigTemplate)
+	if !ok {
+		return fmt.Errorf("expected a RKE2ConfigTemplate object but got %T", obj)
+	}
+
+	RKE2configtemplatelog.Info("default", "name", rct.Name)
 
 	return nil
 }
 
 //+kubebuilder:webhook:path=/validate-bootstrap-cluster-x-k8s-io-v1beta1-rke2configtemplate,mutating=false,failurePolicy=fail,sideEffects=None,groups=bootstrap.cluster.x-k8s.io,resources=rke2configtemplates,verbs=create;update,versions=v1beta1,name=vrke2configtemplate.kb.io,admissionReviewVersions=v1
 
-var _ webhook.CustomValidator = &RKE2ConfigTemplate{}
+var _ webhook.CustomValidator = &RKE2ConfigTemplateCustomValidator{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (r *RKE2ConfigTemplate) ValidateCreate(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
-	RKE2configtemplatelog.Info("validate create", "name", r.Name)
+func (r *RKE2ConfigTemplateCustomValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	rct, ok := obj.(*RKE2ConfigTemplate)
+	if !ok {
+		return nil, fmt.Errorf("expected a RKE2ConfigTemplate object but got %T", obj)
+	}
+
+	RKE2configtemplatelog.Info("validate create", "name", rct.Name)
 
 	return nil, nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (r *RKE2ConfigTemplate) ValidateUpdate(_ context.Context, _, _ runtime.Object) (admission.Warnings, error) {
-	RKE2configtemplatelog.Info("validate update", "name", r.Name)
+func (r *RKE2ConfigTemplateCustomValidator) ValidateUpdate(_ context.Context, oldObj, _ runtime.Object) (admission.Warnings, error) {
+	rct, ok := oldObj.(*RKE2ConfigTemplate)
+	if !ok {
+		return nil, fmt.Errorf("expected a RKE2ConfigTemplate object but got %T", oldObj)
+	}
+
+	RKE2configtemplatelog.Info("validate update", "name", rct.Name)
 
 	return nil, nil
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (r *RKE2ConfigTemplate) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
-	RKE2configtemplatelog.Info("validate delete", "name", r.Name)
+func (r *RKE2ConfigTemplateCustomValidator) ValidateDelete(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	rct, ok := obj.(*RKE2ConfigTemplate)
+	if !ok {
+		return nil, fmt.Errorf("expected a RKE2ConfigTemplate object but got %T", obj)
+	}
+
+	RKE2configtemplatelog.Info("validate delete", "name", rct.Name)
 
 	return nil, nil
 }

--- a/bootstrap/api/v1beta1/webhook_suite_test.go
+++ b/bootstrap/api/v1beta1/webhook_suite_test.go
@@ -105,10 +105,10 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	err = (&RKE2Config{}).SetupWebhookWithManager(mgr)
+	err = SetupRKE2ConfigWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = (&RKE2ConfigTemplate{}).SetupWebhookWithManager(mgr)
+	err = SetupRKE2ConfigTemplateWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:webhook

--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -224,13 +224,13 @@ func setupReconcilers(mgr ctrl.Manager) {
 }
 
 func setupWebhooks(mgr ctrl.Manager) {
-	if err := (&bootstrapv1.RKE2Config{}).SetupWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "Rke2Config")
+	if err := bootstrapv1.SetupRKE2ConfigTemplateWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "RKE2ConfigTemplate")
 		os.Exit(1)
 	}
 
-	if err := (&bootstrapv1.RKE2ConfigTemplate{}).SetupWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "Rke2ConfigTemplate")
+	if err := bootstrapv1.SetupRKE2ConfigWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "RKE2Config")
 		os.Exit(1)
 	}
 }

--- a/controlplane/api/v1beta1/rke2controlplane_webhook.go
+++ b/controlplane/api/v1beta1/rke2controlplane_webhook.go
@@ -37,10 +37,16 @@ var rke2controlplanelog = logf.Log.WithName("rke2controlplane-resource")
 
 // RKE2ControlPlaneCustomDefaulter struct is responsible for setting default values on the custom resource of the
 // Kind RKE2ControlPlane when those are created or updated.
+// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
+// as it is used only for temporary operations and does not need to be deeply copied.
+// +kubebuilder:object:generate=false
 type RKE2ControlPlaneCustomDefaulter struct{}
 
 // RKE2ControlPlaneCustomValidator struct is responsible for validating the RKE2ControlPlane resource
 // when it is created, updated, or deleted.
+// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
+// as it is used only for temporary operations and does not need to be deeply copied.
+// +kubebuilder:object:generate=false
 type RKE2ControlPlaneCustomValidator struct{}
 
 // SetupRKE2ControlPlaneWebhookWithManager sets up the Controller Manager for the Webhook for the RKE2ControlPlaneTemplate resource.

--- a/controlplane/api/v1beta1/rke2controlplane_webhook.go
+++ b/controlplane/api/v1beta1/rke2controlplane_webhook.go
@@ -66,7 +66,7 @@ var _ webhook.CustomDefaulter = &RKE2ControlPlaneCustomDefaulter{}
 func (rd *RKE2ControlPlaneCustomDefaulter) Default(_ context.Context, obj runtime.Object) error {
 	rcp, ok := obj.(*RKE2ControlPlane)
 	if !ok {
-		return fmt.Errorf("expected a RKE2ControlPlane object but got %T", obj)
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a RKE2ControlPlane but got a %T", obj))
 	}
 
 	bootstrapv1.DefaultRKE2ConfigSpec(&rcp.Spec.RKE2ConfigSpec)

--- a/controlplane/api/v1beta1/rke2controlplanetemplate_webhook.go
+++ b/controlplane/api/v1beta1/rke2controlplanetemplate_webhook.go
@@ -63,7 +63,7 @@ var _ webhook.CustomDefaulter = &RKE2ControlPlaneTemplateCustomDefaulter{}
 func (r *RKE2ControlPlaneTemplateCustomDefaulter) Default(_ context.Context, obj runtime.Object) error {
 	rcpt, ok := obj.(*RKE2ControlPlaneTemplate)
 	if !ok {
-		return fmt.Errorf("expected a RKE2ControlPlaneTemplate object but got %T", obj)
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a RKE2ControlPlaneTemplate but got a %T", obj))
 	}
 
 	bootstrapv1.DefaultRKE2ConfigSpec(&rcpt.Spec.Template.Spec.RKE2ConfigSpec)

--- a/controlplane/api/v1beta1/rke2controlplanetemplate_webhook.go
+++ b/controlplane/api/v1beta1/rke2controlplanetemplate_webhook.go
@@ -34,10 +34,16 @@ import (
 
 // RKE2ControlPlaneTemplateCustomDefaulter struct is responsible for setting default values on the custom resource of the
 // Kind RKE2ControlPlaneTemplate when those are created or updated.
+// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
+// as it is used only for temporary operations and does not need to be deeply copied.
+// +kubebuilder:object:generate=false
 type RKE2ControlPlaneTemplateCustomDefaulter struct{}
 
 // RKE2ControlPlaneTemplateCustomValidator struct is responsible for validating the RKE2ControlPlaneTemplate resource
 // when it is created, updated, or deleted.
+// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
+// as it is used only for temporary operations and does not need to be deeply copied.
+// +kubebuilder:object:generate=false
 type RKE2ControlPlaneTemplateCustomValidator struct{}
 
 // SetupRKE2ControlPlaneTemplateWebhookWithManager sets up the Controller Manager for the Webhook for the RKE2ControlPlaneTemplate resource.

--- a/controlplane/api/v1beta1/rke2controlplanetemplate_webhook.go
+++ b/controlplane/api/v1beta1/rke2controlplanetemplate_webhook.go
@@ -19,6 +19,7 @@ package v1beta1
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -31,63 +32,94 @@ import (
 	bootstrapv1 "github.com/rancher/cluster-api-provider-rke2/bootstrap/api/v1beta1"
 )
 
-// SetupWebhookWithManager sets up the Controller Manager for the Webhook for the RKE2ControlPlaneTemplate resource.
-func (r *RKE2ControlPlaneTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
+// RKE2ControlPlaneTemplateCustomDefaulter struct is responsible for setting default values on the custom resource of the
+// Kind RKE2ControlPlaneTemplate when those are created or updated.
+type RKE2ControlPlaneTemplateCustomDefaulter struct{}
+
+// RKE2ControlPlaneTemplateCustomValidator struct is responsible for validating the RKE2ControlPlaneTemplate resource
+// when it is created, updated, or deleted.
+type RKE2ControlPlaneTemplateCustomValidator struct{}
+
+// SetupRKE2ControlPlaneTemplateWebhookWithManager sets up the Controller Manager for the Webhook for the RKE2ControlPlaneTemplate resource.
+func SetupRKE2ControlPlaneTemplateWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(&RKE2ControlPlaneTemplate{}).
+		WithValidator(&RKE2ControlPlaneTemplateCustomValidator{}).
+		WithDefaulter(&RKE2ControlPlaneTemplateCustomDefaulter{}).
 		Complete()
 }
 
 //+kubebuilder:webhook:path=/mutate-controlplane-cluster-x-k8s-io-v1beta1-rke2controlplanetemplate,mutating=true,failurePolicy=fail,sideEffects=None,groups=controlplane.cluster.x-k8s.io,resources=rke2controlplanetemplates,verbs=create;update,versions=v1beta1,name=mrke2controlplanetemplate.kb.io,admissionReviewVersions=v1
 
-var _ webhook.CustomDefaulter = &RKE2ControlPlaneTemplate{}
+var _ webhook.CustomDefaulter = &RKE2ControlPlaneTemplateCustomDefaulter{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (r *RKE2ControlPlaneTemplate) Default(_ context.Context, _ runtime.Object) error {
-	bootstrapv1.DefaultRKE2ConfigSpec(&r.Spec.Template.Spec.RKE2ConfigSpec)
+func (r *RKE2ControlPlaneTemplateCustomDefaulter) Default(_ context.Context, obj runtime.Object) error {
+	rcpt, ok := obj.(*RKE2ControlPlaneTemplate)
+	if !ok {
+		return fmt.Errorf("expected a RKE2ControlPlaneTemplate object but got %T", obj)
+	}
+
+	bootstrapv1.DefaultRKE2ConfigSpec(&rcpt.Spec.Template.Spec.RKE2ConfigSpec)
 
 	return nil
 }
 
 //+kubebuilder:webhook:path=/validate-controlplane-cluster-x-k8s-io-v1beta1-rke2controlplanetemplate,mutating=false,failurePolicy=fail,sideEffects=None,groups=controlplane.cluster.x-k8s.io,resources=rke2controlplanetemplates,verbs=create;update,versions=v1beta1,name=vrke2controlplanetemplate.kb.io,admissionReviewVersions=v1
 
-var _ webhook.CustomValidator = &RKE2ControlPlaneTemplate{}
+var _ webhook.CustomValidator = &RKE2ControlPlaneTemplateCustomValidator{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (r *RKE2ControlPlaneTemplate) ValidateCreate(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
-	rke2controlplanelog.Info("RKE2ControlPlane validate create", "control-plane", klog.KObj(r))
+func (r *RKE2ControlPlaneTemplateCustomValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	rcpt, ok := obj.(*RKE2ControlPlaneTemplate)
+	if !ok {
+		return nil, fmt.Errorf("expected a RKE2ControlPlaneTemplate object but got %T", obj)
+	}
+
+	rke2controlplanelog.Info("RKE2ControlPlane validate create", "control-plane", klog.KObj(rcpt))
 
 	var allErrs field.ErrorList
 
-	allErrs = append(allErrs, bootstrapv1.ValidateRKE2ConfigSpec(r.Name, &r.Spec.Template.Spec.RKE2ConfigSpec)...)
-	allErrs = append(allErrs, r.validateCNI()...)
-	allErrs = append(allErrs, r.validateRegistrationMethod()...)
+	allErrs = append(allErrs, bootstrapv1.ValidateRKE2ConfigSpec(rcpt.Name, &rcpt.Spec.Template.Spec.RKE2ConfigSpec)...)
+	allErrs = append(allErrs, rcpt.validateCNI()...)
+	allErrs = append(allErrs, rcpt.validateRegistrationMethod()...)
 
 	if len(allErrs) == 0 {
 		return nil, nil
 	}
 
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind("RKE2ControlPlane").GroupKind(), r.Name, allErrs)
+	return nil, apierrors.NewInvalid(GroupVersion.WithKind("RKE2ControlPlane").GroupKind(), rcpt.Name, allErrs)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (r *RKE2ControlPlaneTemplate) ValidateUpdate(_ context.Context, old, _ runtime.Object) (admission.Warnings, error) {
-	oldControlplane, ok := old.(*RKE2ControlPlaneTemplate)
+func (r *RKE2ControlPlaneTemplateCustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	oldControlplane, ok := oldObj.(*RKE2ControlPlaneTemplate)
 	if !ok {
-		return nil, apierrors.NewInvalid(GroupVersion.WithKind("RKE2ControlPlane").GroupKind(), r.Name, field.ErrorList{
+		return nil, apierrors.NewInvalid(GroupVersion.WithKind("RKE2ControlPlane").GroupKind(), oldControlplane.Name, field.ErrorList{
 			field.InternalError(nil, errors.New("failed to convert old RKE2ControlPlane to object")),
+		})
+	}
+
+	newControlplane, ok := newObj.(*RKE2ControlPlaneTemplate)
+	if !ok {
+		return nil, apierrors.NewInvalid(GroupVersion.WithKind("RKE2ControlPlane").GroupKind(), oldControlplane.Name, field.ErrorList{
+			field.InternalError(nil, errors.New("failed to convert new RKE2ControlPlane to object")),
 		})
 	}
 
 	var allErrs field.ErrorList
 
-	allErrs = append(allErrs, bootstrapv1.ValidateRKE2ConfigSpec(r.Name, &r.Spec.Template.Spec.RKE2ConfigSpec)...)
-	allErrs = append(allErrs, r.validateCNI()...)
+	allErrs = append(allErrs, bootstrapv1.ValidateRKE2ConfigSpec(newControlplane.Name, &newControlplane.Spec.Template.Spec.RKE2ConfigSpec)...)
+	allErrs = append(allErrs, newControlplane.validateCNI()...)
 
 	oldSet := oldControlplane.Spec.Template.Spec.RegistrationMethod != ""
-	if oldSet && r.Spec.Template.Spec.RegistrationMethod != oldControlplane.Spec.Template.Spec.RegistrationMethod {
+	if oldSet && newControlplane.Spec.Template.Spec.RegistrationMethod != oldControlplane.Spec.Template.Spec.RegistrationMethod {
 		allErrs = append(allErrs,
-			field.Invalid(field.NewPath("spec", "registrationMethod"), r.Spec.Template.Spec.RegistrationMethod, "field value is immutable once set"),
+			field.Invalid(
+				field.NewPath("spec", "registrationMethod"),
+				newControlplane.Spec.Template.Spec.RegistrationMethod,
+				"field value is immutable once set",
+			),
 		)
 	}
 
@@ -95,34 +127,39 @@ func (r *RKE2ControlPlaneTemplate) ValidateUpdate(_ context.Context, old, _ runt
 		return nil, nil
 	}
 
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind("RKE2ControlPlane").GroupKind(), r.Name, allErrs)
+	return nil, apierrors.NewInvalid(GroupVersion.WithKind("RKE2ControlPlane").GroupKind(), newControlplane.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (r *RKE2ControlPlaneTemplate) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
-	rke2controlplanelog.Info("validate delete", "name", r.Name)
+func (r *RKE2ControlPlaneTemplateCustomValidator) ValidateDelete(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	rcpt, ok := obj.(*RKE2ControlPlaneTemplate)
+	if !ok {
+		return nil, fmt.Errorf("expected a RKE2ControlPlaneTemplate object but got %T", obj)
+	}
+
+	rke2controlplanelog.Info("validate delete", "name", rcpt.Name)
 
 	return nil, nil
 }
 
-func (r *RKE2ControlPlaneTemplate) validateCNI() field.ErrorList {
+func (rcpt *RKE2ControlPlaneTemplate) validateCNI() field.ErrorList {
 	var allErrs field.ErrorList
 
-	spec := r.Spec.Template.Spec
+	spec := rcpt.Spec.Template.Spec
 
-	if spec.ServerConfig.CNIMultusEnable && r.Spec.Template.Spec.ServerConfig.CNI == "" {
+	if spec.ServerConfig.CNIMultusEnable && rcpt.Spec.Template.Spec.ServerConfig.CNI == "" {
 		allErrs = append(allErrs,
 			field.Invalid(field.NewPath("spec", "serverConfig", "cni"),
-				r.Spec.Template.Spec.ServerConfig.CNI, "must be specified when cniMultusEnable is true"))
+				rcpt.Spec.Template.Spec.ServerConfig.CNI, "must be specified when cniMultusEnable is true"))
 	}
 
 	return allErrs
 }
 
-func (r *RKE2ControlPlaneTemplate) validateRegistrationMethod() field.ErrorList {
+func (rcpt *RKE2ControlPlaneTemplate) validateRegistrationMethod() field.ErrorList {
 	var allErrs field.ErrorList
 
-	spec := r.Spec.Template.Spec
+	spec := rcpt.Spec.Template.Spec
 
 	if spec.RegistrationMethod == RegistrationMethodAddress {
 		if spec.RegistrationAddress == "" {

--- a/controlplane/api/v1beta1/rke2controlplanetemplate_webhook.go
+++ b/controlplane/api/v1beta1/rke2controlplanetemplate_webhook.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"errors"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -39,19 +40,21 @@ func (r *RKE2ControlPlaneTemplate) SetupWebhookWithManager(mgr ctrl.Manager) err
 
 //+kubebuilder:webhook:path=/mutate-controlplane-cluster-x-k8s-io-v1beta1-rke2controlplanetemplate,mutating=true,failurePolicy=fail,sideEffects=None,groups=controlplane.cluster.x-k8s.io,resources=rke2controlplanetemplates,verbs=create;update,versions=v1beta1,name=mrke2controlplanetemplate.kb.io,admissionReviewVersions=v1
 
-var _ webhook.Defaulter = &RKE2ControlPlaneTemplate{}
+var _ webhook.CustomDefaulter = &RKE2ControlPlaneTemplate{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (r *RKE2ControlPlaneTemplate) Default() {
+func (r *RKE2ControlPlaneTemplate) Default(_ context.Context, _ runtime.Object) error {
 	bootstrapv1.DefaultRKE2ConfigSpec(&r.Spec.Template.Spec.RKE2ConfigSpec)
+
+	return nil
 }
 
 //+kubebuilder:webhook:path=/validate-controlplane-cluster-x-k8s-io-v1beta1-rke2controlplanetemplate,mutating=false,failurePolicy=fail,sideEffects=None,groups=controlplane.cluster.x-k8s.io,resources=rke2controlplanetemplates,verbs=create;update,versions=v1beta1,name=vrke2controlplanetemplate.kb.io,admissionReviewVersions=v1
 
-var _ webhook.Validator = &RKE2ControlPlaneTemplate{}
+var _ webhook.CustomValidator = &RKE2ControlPlaneTemplate{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (r *RKE2ControlPlaneTemplate) ValidateCreate() (admission.Warnings, error) {
+func (r *RKE2ControlPlaneTemplate) ValidateCreate(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	rke2controlplanelog.Info("RKE2ControlPlane validate create", "control-plane", klog.KObj(r))
 
 	var allErrs field.ErrorList
@@ -68,7 +71,7 @@ func (r *RKE2ControlPlaneTemplate) ValidateCreate() (admission.Warnings, error) 
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (r *RKE2ControlPlaneTemplate) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
+func (r *RKE2ControlPlaneTemplate) ValidateUpdate(_ context.Context, old, _ runtime.Object) (admission.Warnings, error) {
 	oldControlplane, ok := old.(*RKE2ControlPlaneTemplate)
 	if !ok {
 		return nil, apierrors.NewInvalid(GroupVersion.WithKind("RKE2ControlPlane").GroupKind(), r.Name, field.ErrorList{
@@ -96,7 +99,7 @@ func (r *RKE2ControlPlaneTemplate) ValidateUpdate(old runtime.Object) (admission
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (r *RKE2ControlPlaneTemplate) ValidateDelete() (admission.Warnings, error) {
+func (r *RKE2ControlPlaneTemplate) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	rke2controlplanelog.Info("validate delete", "name", r.Name)
 
 	return nil, nil

--- a/controlplane/api/v1beta1/rke2controlplanetemplate_webhook_test.go
+++ b/controlplane/api/v1beta1/rke2controlplanetemplate_webhook_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -48,7 +49,7 @@ func TestRKE2ControlPlaneTemplateValidateCreate(t *testing.T) {
 		tt := test
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			warn, err := tt.inputTemplate.ValidateCreate()
+			warn, err := tt.inputTemplate.ValidateCreate(context.Background(), tt.inputTemplate)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {
@@ -96,7 +97,7 @@ func TestRKE2ControlPlaneTemplateValidateUpdate(t *testing.T) {
 		tt := test
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			warn, err := tt.newTemplate.ValidateUpdate(tt.oldTemplate)
+			warn, err := tt.newTemplate.ValidateUpdate(context.Background(), tt.oldTemplate, tt.newTemplate)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/controlplane/api/v1beta1/rke2controlplanetemplate_webhook_test.go
+++ b/controlplane/api/v1beta1/rke2controlplanetemplate_webhook_test.go
@@ -45,11 +45,12 @@ func TestRKE2ControlPlaneTemplateValidateCreate(t *testing.T) {
 			wantErr: true,
 		},
 	}
+	validator := RKE2ControlPlaneTemplateCustomValidator{}
 	for _, test := range tests {
 		tt := test
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			warn, err := tt.inputTemplate.ValidateCreate(context.Background(), tt.inputTemplate)
+			warn, err := validator.ValidateCreate(context.Background(), tt.inputTemplate)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {
@@ -93,11 +94,12 @@ func TestRKE2ControlPlaneTemplateValidateUpdate(t *testing.T) {
 			wantErr: false,
 		},
 	}
+	validator := RKE2ControlPlaneTemplateCustomValidator{}
 	for _, test := range tests {
 		tt := test
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			warn, err := tt.newTemplate.ValidateUpdate(context.Background(), tt.oldTemplate, tt.newTemplate)
+			warn, err := validator.ValidateUpdate(context.Background(), tt.oldTemplate, tt.newTemplate)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/controlplane/api/v1beta1/webhook_suite_test.go
+++ b/controlplane/api/v1beta1/webhook_suite_test.go
@@ -108,10 +108,10 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	err = (&RKE2ControlPlane{}).SetupWebhookWithManager(mgr)
+	err = SetupRKE2ControlPlaneWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = (&RKE2ControlPlaneTemplate{}).SetupWebhookWithManager(mgr)
+	err = SetupRKE2ControlPlaneTemplateWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:webhook

--- a/controlplane/main.go
+++ b/controlplane/main.go
@@ -245,13 +245,13 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 }
 
 func setupWebhooks(mgr ctrl.Manager) {
-	if err := (&controlplanev1.RKE2ControlPlane{}).SetupWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "RKE2ControlPlane")
+	if err := controlplanev1.SetupRKE2ControlPlaneTemplateWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "RKE2ControlPlaneTemplate")
 		os.Exit(1)
 	}
 
-	if err := (&controlplanev1.RKE2ControlPlaneTemplate{}).SetupWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "RKE2ControlPlaneTemplate")
+	if err := controlplanev1.SetupRKE2ControlPlaneWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "RKE2ControlPlane")
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->
kind/*

**What this PR does / why we need it**: `admission.Validator` and `admission.Defaulter` were [marked as Deprecated in controller-runtime v0.17.0](https://github.com/kubernetes-sigs/controller-runtime/releases/tag/v0.17.0). They are [removed in controller-runtime v0.20.0](https://github.com/kubernetes-sigs/controller-runtime/releases/tag/v0.20.0). This addresses the removal and bumps the controller-runtime dependency to [0.20.1](https://github.com/kubernetes-sigs/controller-runtime/releases/tag/v0.20.1) (latest stable)

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
