### PR TITLE
Clarify RKE2 CP Ready field meaning in status

### DIFF
--- a/controlplane/api/v1beta1/rke2controlplane_types.go
+++ b/controlplane/api/v1beta1/rke2controlplane_types.go
@@ -202,7 +202,12 @@ type RKE2ServerConfig struct {
 
 // RKE2ControlPlaneStatus defines the observed state of RKE2ControlPlane.
 type RKE2ControlPlaneStatus struct {
-	// Ready indicates the BootstrapData field is ready to be consumed.
+	// Ready denotes that the RKE2ControlPlane API Server became ready during initial provisioning
+	// to receive requests.
+	// NOTE: this field is part of the Cluster API contract and it is used to orchestrate provisioning.
+	// The value of this field is never updated after provisioning is completed. Please use conditions
+	// to check the operational state of the control plane.
+	// +optional
 	Ready bool `json:"ready,omitempty"`
 
 	// Initialized indicates the target cluster has completed initialization.

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanes.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanes.yaml
@@ -2517,8 +2517,12 @@ spec:
                 format: int64
                 type: integer
               ready:
-                description: Ready indicates the BootstrapData field is ready to be
-                  consumed.
+                description: |-
+                  Ready denotes that the RKE2ControlPlane API Server became ready during initial provisioning
+                  to receive requests.
+                  NOTE: this field is part of the Cluster API contract and it is used to orchestrate provisioning.
+                  The value of this field is never updated after provisioning is completed. Please use conditions
+                  to check the operational state of the control plane.
                 type: boolean
               readyReplicas:
                 description: ReadyReplicas is the number of replicas current attached

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanetemplates.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanetemplates.yaml
@@ -1383,8 +1383,12 @@ spec:
                 format: int64
                 type: integer
               ready:
-                description: Ready indicates the BootstrapData field is ready to be
-                  consumed.
+                description: |-
+                  Ready denotes that the RKE2ControlPlane API Server became ready during initial provisioning
+                  to receive requests.
+                  NOTE: this field is part of the Cluster API contract and it is used to orchestrate provisioning.
+                  The value of this field is never updated after provisioning is completed. Please use conditions
+                  to check the operational state of the control plane.
                 type: boolean
               readyReplicas:
                 description: ReadyReplicas is the number of replicas current attached


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Existing comment seems to be copy paste and creates confusion for users. This PR adds better documentation for the field and its meaning in the context of RKE2 CP resource.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #356 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
