### PR TITLE
Use merge queue to reduce rebase effort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: run ci checks
 
-on: [pull_request, workflow_dispatch]
+on: [pull_request, workflow_dispatch, merge_group]
 
 jobs:
   ci:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,6 +1,7 @@
 name: E2E tests
 on:
   pull_request:
+  merge_group:
   schedule:
     - cron: '0 1 * * *'
   workflow_dispatch:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,6 +1,7 @@
 name: golangci-lint
 
 on:
+  merge_group:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,7 @@
 name: Lint
 
 on:
+  merge_group:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This change enables [merge-queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) on PRs, which should make all PRs merge sequentially with rebases on top of each other.

After merging this PR, we can lift the requirement for PRs to be always up-to-date with main.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
