### PR TITLE
Adds RKE2ControlPlane labels to Machines

### DIFF
--- a/controlplane/internal/controllers/scale.go
+++ b/controlplane/internal/controllers/scale.go
@@ -464,6 +464,10 @@ func (r *RKE2ControlPlaneReconciler) generateMachine(
 		},
 	}
 
+	for k, v := range rcp.Spec.MachineTemplate.ObjectMeta.Labels {
+		machine.Labels[k] = v
+	}
+
 	logger.Info("generating machine:", "machine-spec-version", machine.Spec.Version)
 
 	// Machine's bootstrap config may be missing RKE2Config if it is not the first machine in the control plane.

--- a/test/e2e/data/infrastructure/cluster-template-docker-updated.yaml
+++ b/test/e2e/data/infrastructure/cluster-template-docker-updated.yaml
@@ -117,11 +117,15 @@ spec:
     kubeAPIServer:
       extraArgs:
       - --anonymous-auth=true
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: DockerMachineTemplate
-    name:  "${CLUSTER_NAME}-control-plane"
-  nodeDrainTimeout: 30s
+  machineTemplate:
+    metadata:
+      labels:
+        key: value
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: DockerMachineTemplate
+      name:  "${CLUSTER_NAME}-control-plane"
+    nodeDrainTimeout: 30s
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate

--- a/test/e2e/data/infrastructure/cluster-template-docker.yaml
+++ b/test/e2e/data/infrastructure/cluster-template-docker.yaml
@@ -118,11 +118,15 @@ spec:
     kubeAPIServer:
       extraArgs:
       - --anonymous-auth=true
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: DockerMachineTemplate
-    name:  "${CLUSTER_NAME}-control-plane"
-  nodeDrainTimeout: 30s
+  machineTemplate:
+    metadata:
+      labels:
+        key: value
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: DockerMachineTemplate
+      name: "${CLUSTER_NAME}-control-plane"
+    nodeDrainTimeout: 30s
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate

--- a/test/e2e/e2e_upgrade_test.go
+++ b/test/e2e/e2e_upgrade_test.go
@@ -107,6 +107,7 @@ var _ = Describe("Workload cluster creation", func() {
 				WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster"),
 				WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
 				WaitForMachineDeployments:    e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
+				SkipMachineLabelCheck:        true,
 			}, result)
 
 			WaitForControlPlaneToBeReady(ctx, WaitForControlPlaneToBeReadyInput{
@@ -146,6 +147,7 @@ var _ = Describe("Workload cluster creation", func() {
 				WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster"),
 				WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
 				WaitForMachineDeployments:    e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
+				SkipMachineLabelCheck:        true,
 			}, result)
 
 			WaitForControlPlaneToBeReady(ctx, WaitForControlPlaneToBeReadyInput{
@@ -171,6 +173,7 @@ var _ = Describe("Workload cluster creation", func() {
 				WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster"),
 				WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
 				WaitForMachineDeployments:    e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
+				SkipMachineLabelCheck:        true,
 			}, result)
 
 			WaitForClusterToUpgrade(ctx, WaitForClusterToUpgradeInput{

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -62,6 +62,7 @@ type ApplyClusterTemplateAndWaitInput struct {
 	Args                         []string
 	PreWaitForCluster            func()
 	PostMachinesProvisioned      func()
+	SkipMachineLabelCheck        bool
 	ControlPlaneWaiters
 }
 
@@ -78,6 +79,7 @@ type ApplyCustomClusterTemplateAndWaitInput struct {
 	Args                         []string
 	PreWaitForCluster            func()
 	PostMachinesProvisioned      func()
+	SkipMachineLabelCheck        bool
 	ControlPlaneWaiters
 }
 
@@ -152,6 +154,7 @@ func ApplyClusterTemplateAndWait(ctx context.Context, input ApplyClusterTemplate
 		PreWaitForCluster:            input.PreWaitForCluster,
 		PostMachinesProvisioned:      input.PostMachinesProvisioned,
 		ControlPlaneWaiters:          input.ControlPlaneWaiters,
+		SkipMachineLabelCheck:        input.SkipMachineLabelCheck,
 	}, (*ApplyCustomClusterTemplateAndWaitResult)(result))
 }
 
@@ -304,9 +307,10 @@ func GetRKE2ControlPlaneByCluster(ctx context.Context, input GetRKE2ControlPlane
 
 // WaitForControlPlaneAndMachinesReadyInput is the input type for WaitForControlPlaneAndMachinesReady.
 type WaitForControlPlaneAndMachinesReadyInput struct {
-	GetLister    framework.GetLister
-	Cluster      *clusterv1.Cluster
-	ControlPlane *controlplanev1.RKE2ControlPlane
+	GetLister             framework.GetLister
+	Cluster               *clusterv1.Cluster
+	ControlPlane          *controlplanev1.RKE2ControlPlane
+	SkipMachineLabelCheck bool
 }
 
 // WaitForControlPlaneAndMachinesReady waits for a RKE2ControlPlane object to be ready (all the machine provisioned and one node ready).
@@ -319,9 +323,10 @@ func WaitForControlPlaneAndMachinesReady(ctx context.Context, input WaitForContr
 	if input.ControlPlane.Spec.Replicas != nil && int(*input.ControlPlane.Spec.Replicas) > 1 {
 		By(fmt.Sprintf("Waiting for the remaining control plane machines managed by %s to be provisioned", klog.KObj(input.ControlPlane)))
 		WaitForRKE2ControlPlaneMachinesToExist(ctx, WaitForRKE2ControlPlaneMachinesToExistInput{
-			Lister:       input.GetLister,
-			Cluster:      input.Cluster,
-			ControlPlane: input.ControlPlane,
+			Lister:                input.GetLister,
+			Cluster:               input.Cluster,
+			ControlPlane:          input.ControlPlane,
+			SkipMachineLabelCheck: input.SkipMachineLabelCheck,
 		}, intervals...)
 	}
 
@@ -340,9 +345,10 @@ func WaitForControlPlaneAndMachinesReady(ctx context.Context, input WaitForContr
 
 // WaitForRKE2ControlPlaneMachinesToExistInput is the input for WaitForRKE2ControlPlaneMachinesToExist.
 type WaitForRKE2ControlPlaneMachinesToExistInput struct {
-	Lister       framework.Lister
-	Cluster      *clusterv1.Cluster
-	ControlPlane *controlplanev1.RKE2ControlPlane
+	Lister                framework.Lister
+	Cluster               *clusterv1.Cluster
+	ControlPlane          *controlplanev1.RKE2ControlPlane
+	SkipMachineLabelCheck bool
 }
 
 // WaitForRKE2ControlPlaneMachinesToExist will wait until all control plane machines have node refs.
@@ -370,17 +376,18 @@ func WaitForRKE2ControlPlaneMachinesToExist(ctx context.Context, input WaitForRK
 		return count, nil
 	}, intervals...).Should(Equal(int(*input.ControlPlane.Spec.Replicas)), "Timed out waiting for %d control plane machines to exist", int(*input.ControlPlane.Spec.Replicas))
 
-	controlPlaneMachineTemplateLabels := input.ControlPlane.Spec.MachineTemplate.ObjectMeta.Labels
+	if !input.SkipMachineLabelCheck {
+		// check if machines owned by RKE2ControlPlane have the labels provided in .spec.machineTemplate.metadata.labels
+		controlPlaneMachineTemplateLabels := input.ControlPlane.Spec.MachineTemplate.ObjectMeta.Labels
+		machineList := &clusterv1.MachineList{}
+		err := input.Lister.List(ctx, machineList, inClustersNamespaceListOption, matchClusterListOption)
+		Expect(err).To(BeNil(), "failed to list the machines")
 
-	// check if machines owned by RKE2ControlPlane have the labels provided in .spec.machineTemplate.metadata.labels
-	machineList := &clusterv1.MachineList{}
-	err := input.Lister.List(ctx, machineList, inClustersNamespaceListOption, matchClusterListOption)
-	Expect(err).To(BeNil(), "failed to list the machines")
-
-	for _, machine := range machineList.Items {
-		machineLabels := machine.ObjectMeta.Labels
-		for k := range controlPlaneMachineTemplateLabels {
-			Expect(machineLabels[k]).To(Equal(controlPlaneMachineTemplateLabels[k]))
+		for _, machine := range machineList.Items {
+			machineLabels := machine.ObjectMeta.Labels
+			for k := range controlPlaneMachineTemplateLabels {
+				Expect(machineLabels[k]).To(Equal(controlPlaneMachineTemplateLabels[k]))
+			}
 		}
 	}
 }
@@ -517,9 +524,10 @@ func setDefaults(input *ApplyCustomClusterTemplateAndWaitInput) {
 	if input.WaitForControlPlaneMachinesReady == nil {
 		input.WaitForControlPlaneMachinesReady = func(ctx context.Context, input ApplyCustomClusterTemplateAndWaitInput, result *ApplyCustomClusterTemplateAndWaitResult) {
 			WaitForControlPlaneAndMachinesReady(ctx, WaitForControlPlaneAndMachinesReadyInput{
-				GetLister:    input.ClusterProxy.GetClient(),
-				Cluster:      result.Cluster,
-				ControlPlane: result.ControlPlane,
+				GetLister:             input.ClusterProxy.GetClient(),
+				Cluster:               result.Cluster,
+				ControlPlane:          result.ControlPlane,
+				SkipMachineLabelCheck: input.SkipMachineLabelCheck,
 			}, input.WaitForControlPlaneIntervals...)
 		}
 	}


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
$subject. For details, refer #517.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #517 

**Special notes for your reviewer**:
1. This PR has two commits. First one modifies the function signature and requires a change at all places it's called. Second one uses a `for` loop to make changes only at the place where I think it's reuired. Please suggest which commit to keep of the two.
2. I have tested this using the following manifest:
    <details>
    <summary> manifest </summary>

    ```yaml
    apiVersion: v1
    kind: Namespace
    metadata:
      name: example-docker
    ---
    apiVersion: cluster.x-k8s.io/v1beta1
    kind: Cluster
    metadata:
      name: rke2-docker
      namespace: example-docker
    spec:
      clusterNetwork:
        pods:
          cidrBlocks:
          - 10.45.0.0/16
        serviceDomain: cluster.local
        services:
          cidrBlocks:
          - 10.46.0.0/16
      controlPlaneRef:
        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
        kind: RKE2ControlPlane
        name: rke2-docker-control-plane
      infrastructureRef:
        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
        kind: DockerCluster
        name: rke2-docker
    ---
    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
    kind: DockerCluster
    metadata:
      name: rke2-docker
      namespace: example-docker
    spec:
      loadBalancer:
        customHAProxyConfigTemplateRef:
          name: rke2-docker-lb-config
    ---
    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
    kind: RKE2ControlPlane
    metadata:
      name: rke2-docker-control-plane
      namespace: example-docker
      labels:
        key: value
    spec:
      agentConfig: {}
      machineTemplate:
        infrastructureRef:
          apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
          kind: DockerMachineTemplate
          name: controlplane
        nodeDrainTimeout: 2m
      registrationMethod: control-plane-endpoint
      replicas: 1
      rolloutStrategy:
        rollingUpdate:
          maxSurge: 0
        type: RollingUpdate
      serverConfig:
        disableComponents:
          kubernetesComponents:
          - cloudController
        kubeAPIServer:
          extraArgs:
          - --anonymous-auth=true
      version: v1.30.2+rke2r1
    ---
    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
    kind: DockerMachineTemplate
    metadata:
      name: controlplane
      namespace: example-docker
    spec:
      template:
        spec:
          bootstrapTimeout: 15m
          customImage: kindest/node:v1.30.0
    ---
    apiVersion: cluster.x-k8s.io/v1beta1
    kind: MachineDeployment
    metadata:
      name: worker-md-0
      namespace: example-docker
    spec:
      clusterName: rke2-docker
      replicas: 1
      selector:
        matchLabels:
          cluster.x-k8s.io/cluster-name: rke2-docker
      template:
        spec:
          bootstrap:
            configRef:
              apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
              kind: RKE2ConfigTemplate
              name: rke2-docker-agent
              namespace: example-docker
          clusterName: rke2-docker
          infrastructureRef:
            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
            kind: DockerMachineTemplate
            name: worker
            namespace: example-docker
          version: v1.30.2+rke2r1
    ---
    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
    kind: DockerMachineTemplate
    metadata:
      name: worker
      namespace: example-docker
    spec:
      template:
        spec:
          bootstrapTimeout: 15m
          customImage: kindest/node:v1.30.0
    ---
    apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
    kind: RKE2ConfigTemplate
    metadata:
      name: rke2-docker-agent
      namespace: example-docker
    spec:
      template:
        spec:
          agentConfig: {}
    ---
    apiVersion: v1
    data:
      value: |-
        # generated by kind
        global
          log /dev/log local0
          log /dev/log local1 notice
          daemon
          # limit memory usage to approximately 18 MB
          # (see https://github.com/kubernetes-sigs/kind/pull/3115)
          maxconn 100000

        resolvers docker
          nameserver dns 127.0.0.11:53

        defaults
          log global
          mode tcp
          option dontlognull
          # TODO: tune these
          timeout connect 5000
          timeout client 50000
          timeout server 50000
          # allow to boot despite dns don't resolve backends
          default-server init-addr none

        frontend stats
          mode http
          bind *:8404
          stats enable
          stats uri /stats
          stats refresh 1s
          stats admin if TRUE

        frontend control-plane
          bind *:{{ .FrontendControlPlanePort }}
          {{ if .IPv6 -}}
          bind :::{{ .FrontendControlPlanePort }};
          {{- end }}
          default_backend kube-apiservers

        backend kube-apiservers
          option httpchk GET /healthz

          {{range $server, $backend := .BackendServers}}
          server {{ $server }} {{ JoinHostPort $backend.Address $.BackendControlPlanePort }} check check-ssl verify none resolvers docker resolve-prefer {{ if $.IPv6 -}} ipv6 {{- else -}} ipv4 {{- end }}
          {{- end}}

        frontend rke2-join
          bind *:9345
          {{ if .IPv6 -}}
          bind :::9345;
          {{- end }}
          default_backend rke2-servers

        backend rke2-servers
          option httpchk GET /v1-rke2/readyz
          http-check expect status 403
          {{range $server, $backend := .BackendServers}}
          server {{ $server }} {{ $backend.Address }}:9345 check check-ssl verify none
          {{- end}}
    kind: ConfigMap
    metadata:
      name: rke2-docker-lb-config
      namespace: example-docker
    ```

    </details>

    And then using below command:
    ```sh
    $ k get machines -o jsonpath='{range .items[*]}{.metadata.labels}' | jq
    {
      "cluster.x-k8s.io/cluster-name": "rke2-docker",
      "cluster.x-k8s.io/control-plane": "",
      "key": "value"
    }
    ```
  

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
