### PR TITLE
Add more nuances to e2e test configuration

### DIFF
--- a/test/e2e/data/infrastructure/cluster-template-docker.yaml
+++ b/test/e2e/data/infrastructure/cluster-template-docker.yaml
@@ -107,6 +107,12 @@ spec:
     rollingUpdate:
       maxSurge: 1
   agentConfig:
+    format: cloud-config
+    kubelet:
+      extraArgs:
+      - anonymous-auth=true
+    ntp:
+      enabled: true
     nodeAnnotations:
       test: "true"
   serverConfig:
@@ -127,6 +133,15 @@ spec:
       kind: DockerMachineTemplate
       name: "${CLUSTER_NAME}-control-plane"
     nodeDrainTimeout: 30s
+  preRKE2Commands:
+  - touch /pre-rke2-command.sentinel
+  postRKE2Commands:
+  - touch /post-rke2-command.sentinel
+  files:
+  - content: "Just a dummy file\n"
+    owner: root:root
+    path: /control-plane-file.sentinel
+    permissions: "0755"   
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate


### PR DESCRIPTION
**What this PR does / why we need it**:
Related to: #596

This adds a little bit more complexity to the Cluster template, first to ensure it still works, but also to verify whether some fields accidentally trigger a rollout.

This does not seem to be the case still. Also tested locally from `0.7.1` to `main`.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
