### PR TITLE
Allow using Gzip and GzipBase64 encoding in case of cloud-init format

### DIFF
--- a/bootstrap/api/v1beta1/rke2config_webhook.go
+++ b/bootstrap/api/v1beta1/rke2config_webhook.go
@@ -186,17 +186,17 @@ func (s *RKE2ConfigSpec) validateIgnition(pathPrefix *field.Path) field.ErrorLis
 				),
 			)
 		}
-	}
 
-	for i, file := range s.Files {
-		if file.Encoding == Gzip || file.Encoding == GzipBase64 {
-			allErrs = append(
-				allErrs,
-				field.Forbidden(
-					pathPrefix.Child("files").Index(i).Child("encoding"),
-					cannotUseWithIgnition,
-				),
-			)
+		for i, file := range s.Files {
+			if file.Encoding == Gzip || file.Encoding == GzipBase64 {
+				allErrs = append(
+					allErrs,
+					field.Forbidden(
+						pathPrefix.Child("files").Index(i).Child("encoding"),
+						cannotUseWithIgnition,
+					),
+				)
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

When configuring RKE2ControlPlane with a file using `gzip+base64` encoding, the bootstrap controller fails with the error : 
```
spec.files[2].encoding: Forbidden: not supported when spec.format is set to "ignition"
```
Even if the format used is cloud-init.

This PR validates the file encoding is not `gzip` or `gzip+base64` __only__ in case of ignition format.
