### PR TITLE
Move sshd config into included subdir

### DIFF
--- a/bootstrap/internal/ignition/butane/butane.go
+++ b/bootstrap/internal/ignition/butane/butane.go
@@ -74,7 +74,7 @@ storage:
       mount_options:
        - "subvol=/@/opt"
   files:
-    - path: /etc/ssh/sshd_config
+    - path: /etc/ssh/sshd_config.d/010-rke2.conf
       mode: 0600
       overwrite: true
       contents:

--- a/bootstrap/internal/ignition/butane/butane_test.go
+++ b/bootstrap/internal/ignition/butane/butane_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Render", func() {
 
 		Expect(ign.Storage.Files).To(HaveLen(5))
 
-		Expect(ign.Storage.Files[0].Path).To(Equal("/etc/ssh/sshd_config"))
+		Expect(ign.Storage.Files[0].Path).To(Equal("/etc/ssh/sshd_config.d/010-rke2.conf"))
 
 		Expect(ign.Storage.Files[1].Path).To(Equal("/test/file"))
 

--- a/bootstrap/internal/ignition/ignition_test.go
+++ b/bootstrap/internal/ignition/ignition_test.go
@@ -93,7 +93,7 @@ var _ = Describe("NewJoinWorker", func() {
 		Expect(reports.IsFatal()).To(BeFalse())
 
 		Expect(ign.Storage.Files).To(HaveLen(4))
-		Expect(ign.Storage.Files[0].Path).To(Equal("/etc/ssh/sshd_config"))
+		Expect(ign.Storage.Files[0].Path).To(Equal("/etc/ssh/sshd_config.d/010-rke2.conf"))
 		Expect(ign.Storage.Files[1].Path).To(Equal("/test/file"))
 		Expect(ign.Storage.Files[2].Path).To(Equal("/test/config"))
 		Expect(ign.Storage.Files[3].Path).To(Equal("/etc/rke2-install.sh"))
@@ -124,7 +124,7 @@ var _ = Describe("NewJoinWorker", func() {
 		Expect(reports.IsFatal()).To(BeFalse())
 
 		Expect(ign.Storage.Files).To(HaveLen(4))
-		Expect(ign.Storage.Files[0].Path).To(Equal("/etc/ssh/sshd_config"))
+		Expect(ign.Storage.Files[0].Path).To(Equal("/etc/ssh/sshd_config.d/010-rke2.conf"))
 		Expect(ign.Storage.Files[1].Path).To(Equal("/test/file"))
 		Expect(ign.Storage.Files[2].Path).To(Equal("/test/config"))
 		Expect(ign.Storage.Files[3].Path).To(Equal("/etc/rke2-install.sh"))


### PR DESCRIPTION
By writing into /etc/ssh/sshd_config we override default config which usually defines include /etc/ssh/sshd_config.d/*.conf. This breaks an ability to cusomize config further. And disables include any files dropped into sshd_config.d directory.

This commit moves RKE2 sshd config into subdirectory with 010 index so it will be loaded first.

kind/bug

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
