### PR TITLE
Add kubeconfig rotate tests

### DIFF
--- a/controlplane/internal/controllers/rke2controlplane_controller_test.go
+++ b/controlplane/internal/controllers/rke2controlplane_controller_test.go
@@ -1,22 +1,159 @@
 package controllers
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"math/big"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	bootstrapv1 "github.com/rancher/cluster-api-provider-rke2/bootstrap/api/v1beta1"
 	controlplanev1 "github.com/rancher/cluster-api-provider-rke2/controlplane/api/v1beta1"
-	// "github.com/rancher/cluster-api-provider-rke2/pkg/kubeconfig"
 	"github.com/rancher/cluster-api-provider-rke2/pkg/rke2"
+	"github.com/rancher/cluster-api-provider-rke2/pkg/secret"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/certs"
 	"sigs.k8s.io/cluster-api/util/collections"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/kubeconfig"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+var _ = Describe("Rotate kubeconfig cert", func() {
+	var (
+		err              error
+		ns               *corev1.Namespace
+		rcp              *controlplanev1.RKE2ControlPlane
+		caSecret         *corev1.Secret
+		ccaSecret        *corev1.Secret
+		kubeconfigSecret *corev1.Secret
+		clusterKey       client.ObjectKey
+	)
+	BeforeEach(func() {
+		kubeconfigSecret = &corev1.Secret{}
+		ns, err = testEnv.CreateNamespace(ctx, "rotate-kubeconfig-cert")
+		Expect(err).ToNot(HaveOccurred())
+		clusterKey = client.ObjectKey{Namespace: ns.Name, Name: "rotate-kubeconfig-cert"}
+
+		rcp = &controlplanev1.RKE2ControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: ns.Name,
+				UID:       "foobar",
+			},
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: controlplanev1.GroupVersion.String(),
+				Kind:       rke2ControlPlaneKind,
+			},
+		}
+
+		// Generate new Secret Cluster CA
+		certPEM, _, err := generateCertAndKey(time.Now().Add(3650 * 24 * time.Hour)) // 10 years from now
+		Expect(err).ShouldNot(HaveOccurred())
+		caSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secret.Name(clusterKey.Name, secret.ClusterCA),
+				Namespace: ns.Name,
+			},
+			StringData: map[string]string{
+				secret.TLSCrtDataName: string(certPEM),
+			},
+		}
+		Expect(testEnv.Client.Create(ctx, caSecret)).Should(Succeed())
+		Expect(testEnv.Get(ctx, client.ObjectKeyFromObject(caSecret), caSecret)).Should(Succeed())
+
+		// Generate new Secret Client Cluster CA
+		certPEM, keyPEM, err := generateCertAndKey(time.Now().Add(3650 * 24 * time.Hour)) // 10 years from now
+		Expect(err).ShouldNot(HaveOccurred())
+		ccaSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secret.Name(clusterKey.Name, secret.ClientClusterCA),
+				Namespace: ns.Name,
+			},
+			StringData: map[string]string{
+				secret.TLSCrtDataName: string(certPEM),
+				secret.TLSKeyDataName: string(keyPEM),
+			},
+		}
+		Expect(testEnv.Client.Create(ctx, ccaSecret)).Should(Succeed())
+		Expect(testEnv.Get(ctx, client.ObjectKeyFromObject(ccaSecret), ccaSecret)).Should(Succeed())
+	})
+
+	AfterEach(func() {
+		testEnv.Cleanup(ctx, kubeconfigSecret, ccaSecret, caSecret, ns)
+	})
+	It("Should rotate kubeconfig secret if needed", func() {
+		By("Creating the first kubeconfig if not existing yet")
+		r := &RKE2ControlPlaneReconciler{
+			Client:                    testEnv.GetClient(),
+			Scheme:                    testEnv.GetScheme(),
+			managementCluster:         &rke2.Management{Client: testEnv.GetClient(), SecretCachingClient: testEnv.GetClient()},
+			managementClusterUncached: &rke2.Management{Client: testEnv.GetClient()},
+		}
+		endpoint := clusterv1.APIEndpoint{Host: "1.2.3.4", Port: 6443}
+
+		// Trigger first reconcile to generate a new Kubeconfig Secret
+		Expect(testEnv.Get(ctx, client.ObjectKeyFromObject(caSecret), caSecret)).Should(Succeed())
+		_, err = r.reconcileKubeconfig(ctx, clusterKey, endpoint, rcp)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Fetch the original Kubeconfig Secret
+		Expect(testEnv.Get(ctx, types.NamespacedName{
+			Namespace: ns.Name,
+			Name:      secret.Name(clusterKey.Name, secret.Kubeconfig),
+		}, kubeconfigSecret)).Should(Succeed())
+		originalSecret := kubeconfigSecret.DeepCopy()
+
+		By("Overriding the kubeconfig secret with short expiry")
+		shortExpiryDate := time.Now().Add(24 * time.Hour) // 1 day from now
+		Expect(updateKubeconfigSecret(kubeconfigSecret, shortExpiryDate)).Should(Succeed())
+		Expect(testEnv.Update(ctx, kubeconfigSecret)).To(Succeed())
+
+		By("Checking that rotation is needed")
+		needsRotation, err := kubeconfig.NeedsClientCertRotation(kubeconfigSecret, certs.ClientCertificateRenewalDuration)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(needsRotation).To(BeTrue())
+
+		By("Rotating kubeconfig secret")
+		_, err = r.reconcileKubeconfig(ctx, clusterKey, endpoint, rcp)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(testEnv.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: kubeconfigSecret.Name}, kubeconfigSecret)).To(Succeed())
+		Expect(kubeconfigSecret.StringData[secret.KubeconfigDataName]).Should(Equal(originalSecret.StringData[secret.KubeconfigDataName]), "Kubeconfig data must have been updated")
+
+		By("Override the kubeconfig secret with a long expiry")
+		longExpiryDate := time.Now().Add(365 * 24 * time.Hour) // 1 year from now
+		Expect(updateKubeconfigSecret(kubeconfigSecret, longExpiryDate)).Should(Succeed())
+		Expect(testEnv.Update(ctx, kubeconfigSecret)).To(Succeed())
+
+		By("Checking that rotation is not needed")
+		needsRotation, err = kubeconfig.NeedsClientCertRotation(kubeconfigSecret, certs.ClientCertificateRenewalDuration)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(needsRotation).To(BeFalse())
+
+		By("Fetching the overridden kubeconfig Secret")
+		Expect(testEnv.Get(ctx, types.NamespacedName{
+			Namespace: ns.Name,
+			Name:      secret.Name(clusterKey.Name, secret.Kubeconfig),
+		}, kubeconfigSecret)).Should(Succeed())
+		updatedSecret := kubeconfigSecret.DeepCopy()
+
+		By("Ensuring no rotation occurs")
+		_, err = r.reconcileKubeconfig(ctx, clusterKey, endpoint, rcp)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(testEnv.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: kubeconfigSecret.Name}, kubeconfigSecret)).To(Succeed())
+		Expect(kubeconfigSecret.StringData[secret.KubeconfigDataName]).Should(Equal(updatedSecret.StringData[secret.KubeconfigDataName]), "Kubeconfig data must stay the same")
+	})
+})
 
 var _ = Describe("Reconcile control plane conditions", func() {
 	var (
@@ -69,7 +206,7 @@ var _ = Describe("Reconcile control plane conditions", func() {
 			},
 		}
 		Expect(testEnv.Create(ctx, node.DeepCopy())).To(Succeed())
-		Eventually(testEnv.Get(ctx, client.ObjectKeyFromObject(node), node)).Should(Succeed())
+		Expect(testEnv.Get(ctx, client.ObjectKeyFromObject(node), node)).Should(Succeed())
 		Expect(testEnv.Status().Update(ctx, node.DeepCopy())).To(Succeed())
 
 		nodeRefName := "ref-node"
@@ -136,9 +273,7 @@ var _ = Describe("Reconcile control plane conditions", func() {
 			},
 		}
 		Expect(testEnv.Create(ctx, nodeByRef.DeepCopy())).To(Succeed())
-		Eventually(func() error {
-			return testEnv.Get(ctx, client.ObjectKeyFromObject(nodeByRef), nodeByRef)
-		}, 5*time.Second).Should(Succeed())
+		Expect(testEnv.Get(ctx, client.ObjectKeyFromObject(nodeByRef), nodeByRef)).Should(Succeed())
 		Expect(testEnv.Status().Update(ctx, nodeByRef.DeepCopy())).To(Succeed())
 
 		orphanedNode = &corev1.Node{ObjectMeta: metav1.ObjectMeta{
@@ -256,3 +391,64 @@ var _ = Describe("Reconcile control plane conditions", func() {
 			"Control plane node missing-machine does not have a corresponding machine"))
 	})
 })
+
+// generateCertAndKey generates a self-signed certificate and private key.
+func generateCertAndKey(expiryDate time.Time) ([]byte, []byte, error) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Test Org"},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  expiryDate,
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)})
+
+	return certPEM, keyPEM, nil
+}
+
+// updateKubeconfigSecret updates a Kubernetes secret with a kubeconfig containing a client certificate and key.
+func updateKubeconfigSecret(configSecret *corev1.Secret, expiryDate time.Time) error {
+	certPEM, keyPEM, err := generateCertAndKey(expiryDate)
+	if err != nil {
+		return fmt.Errorf("Generating Cert and Key: %w", err)
+	}
+
+	configSecret.Data[secret.KubeconfigDataName] = []byte(fmt.Sprintf(`
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://1.2.3.4:6443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+users:
+- name: test-user
+  user:
+    client-certificate-data: %s
+    client-key-data: %s
+`, base64.StdEncoding.EncodeToString(certPEM), base64.StdEncoding.EncodeToString(keyPEM)))
+
+	return nil
+}

--- a/controlplane/internal/controllers/suite_test.go
+++ b/controlplane/internal/controllers/suite_test.go
@@ -23,6 +23,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	// +kubebuilder:scaffold:imports
 	bootstrapv1 "github.com/rancher/cluster-api-provider-rke2/bootstrap/api/v1beta1"
 	controlplanev1 "github.com/rancher/cluster-api-provider-rke2/controlplane/api/v1beta1"

--- a/pkg/rke2/management_cluster.go
+++ b/pkg/rke2/management_cluster.go
@@ -139,7 +139,7 @@ func (m *Management) getEtcdCAKeyPair(ctx context.Context, cl ctrlclient.Reader,
 	// Try to get the certificate via the cached ctrlclient.
 	if err := certificates.Lookup(ctx, cl, clusterKey); err != nil {
 		// Return error if we got an errors which is not a NotFound error.
-		return nil, errors.Wrapf(err, "failed to get secret CA bungle; etcd CA bundle %s/%s", clusterKey.Namespace, secretName)
+		return nil, errors.Wrapf(err, "failed to get secret CA bundle; etcd CA bundle %s/%s", clusterKey.Namespace, secretName)
 	}
 
 	var keypair *certs.KeyPair

--- a/pkg/rke2/workload_cluster_test.go
+++ b/pkg/rke2/workload_cluster_test.go
@@ -32,11 +32,13 @@ var _ = Describe("Node metadata propagation", func() {
 		machineDifferentNode *clusterv1.Machine
 		machineNodeRefStatus clusterv1.MachineStatus
 		config               *bootstrapv1.RKE2Config
+		clusterKey           client.ObjectKey
 	)
 
 	BeforeEach(func() {
 		ns, err = testEnv.CreateNamespace(ctx, "ns")
 		Expect(err).ToNot(HaveOccurred())
+		clusterKey = types.NamespacedName{Namespace: ns.Name, Name: "cluster"}
 
 		annotations := map[string]string{
 			"test": "true",
@@ -66,7 +68,7 @@ var _ = Describe("Node metadata propagation", func() {
 				Namespace: ns.Name,
 			},
 			Spec: clusterv1.MachineSpec{
-				ClusterName: "cluster",
+				ClusterName: clusterKey.Name,
 				Bootstrap: clusterv1.Bootstrap{
 					ConfigRef: &corev1.ObjectReference{
 						Kind:       "RKE2Config",
@@ -90,7 +92,7 @@ var _ = Describe("Node metadata propagation", func() {
 				Namespace: ns.Name,
 			},
 			Spec: clusterv1.MachineSpec{
-				ClusterName: "cluster",
+				ClusterName: clusterKey.Name,
 				Bootstrap: clusterv1.Bootstrap{
 					ConfigRef: &corev1.ObjectReference{
 						Kind:       "RKE2Config",
@@ -134,7 +136,7 @@ var _ = Describe("Node metadata propagation", func() {
 			SecretCachingClient: testEnv,
 		}
 
-		w, err := m.NewWorkload(ctx, testEnv.GetClient(), testEnv.GetConfig(), types.NamespacedName{})
+		w, err := m.NewWorkload(ctx, testEnv.GetClient(), testEnv.GetConfig(), clusterKey)
 		Expect(err).ToNot(HaveOccurred())
 
 		cp, err := NewControlPlane(ctx, m, testEnv.GetClient(), nil, nil, machines)
@@ -165,7 +167,7 @@ var _ = Describe("Node metadata propagation", func() {
 			SecretCachingClient: testEnv,
 		}
 
-		w, err := m.NewWorkload(ctx, testEnv.GetClient(), testEnv.GetConfig(), types.NamespacedName{})
+		w, err := m.NewWorkload(ctx, testEnv.GetClient(), testEnv.GetConfig(), clusterKey)
 		Expect(err).ToNot(HaveOccurred())
 		cp, err := NewControlPlane(ctx, m, testEnv.GetClient(), nil, nil, machines)
 		Expect(err).ToNot(HaveOccurred())
@@ -195,7 +197,7 @@ var _ = Describe("Node metadata propagation", func() {
 			SecretCachingClient: testEnv,
 		}
 
-		w, err := m.NewWorkload(ctx, testEnv.GetClient(), testEnv.GetConfig(), types.NamespacedName{})
+		w, err := m.NewWorkload(ctx, testEnv.GetClient(), testEnv.GetConfig(), clusterKey)
 		Expect(err).ToNot(HaveOccurred())
 		cp, err := NewControlPlane(ctx, m, testEnv.GetClient(), nil, nil, machines)
 		Expect(err).ToNot(HaveOccurred())
@@ -242,7 +244,7 @@ var _ = Describe("Node metadata propagation", func() {
 			SecretCachingClient: testEnv,
 		}
 
-		w, err := m.NewWorkload(ctx, testEnv.GetClient(), testEnv.GetConfig(), types.NamespacedName{})
+		w, err := m.NewWorkload(ctx, testEnv.GetClient(), testEnv.GetConfig(), clusterKey)
 		Expect(err).ToNot(HaveOccurred())
 		cp, err := NewControlPlane(ctx, m, testEnv.GetClient(), nil, nil, machines)
 		Expect(w.InitWorkload(ctx, cp)).ToNot(HaveOccurred())
@@ -288,7 +290,7 @@ var _ = Describe("Node metadata propagation", func() {
 			SecretCachingClient: testEnv,
 		}
 
-		w, err := m.NewWorkload(ctx, testEnv.GetClient(), testEnv.GetConfig(), types.NamespacedName{})
+		w, err := m.NewWorkload(ctx, testEnv.GetClient(), testEnv.GetConfig(), clusterKey)
 		Expect(err).ToNot(HaveOccurred())
 		cp, err := NewControlPlane(ctx, m, testEnv.GetClient(), nil, nil, machines)
 		Expect(err).ToNot(HaveOccurred())
@@ -338,7 +340,7 @@ var _ = Describe("Node metadata propagation", func() {
 			SecretCachingClient: testEnv,
 		}
 
-		w, err := m.NewWorkload(ctx, testEnv.GetClient(), testEnv.GetConfig(), types.NamespacedName{})
+		w, err := m.NewWorkload(ctx, testEnv.GetClient(), testEnv.GetConfig(), clusterKey)
 		Expect(err).ToNot(HaveOccurred())
 		cp, err := NewControlPlane(ctx, m, testEnv.GetClient(), nil, nil, machines)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -134,6 +134,14 @@ func (t *TestEnvironmentConfiguration) Build() (*TestEnvironment, error) {
 		Metrics: metricsserver.Options{
 			BindAddress: "0",
 		},
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{
+					&corev1.ConfigMap{},
+					&corev1.Secret{},
+				},
+			},
+		},
 	}
 
 	mgr, err := ctrl.NewManager(t.env.Config, options)


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a continuation of #550 
The existing functionality added by #521 did not look correct, as it was trying to create an existing secret, therefore I assume it would fail.

I fixed it to patch the Secret instead.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #520 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
