### PR TITLE
[0.15] Prevent Machine rollouts before machineTemplate has been updated

### DIFF
--- a/bootstrap/config/manager/manager.yaml
+++ b/bootstrap/config/manager/manager.yaml
@@ -25,6 +25,7 @@ spec:
         - "--diagnostics-address=${CAPRKE2_DIAGNOSTICS_ADDRESS:=:8443}"
         - "--insecure-diagnostics=${CAPRKE2_INSECURE_DIAGNOSTICS:=false}"
         - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=true}"
+        - "--v=${CAPRKE2_DEBUG_LEVEL:=0}"
         image: controller:latest
         name: manager
         ports:

--- a/controlplane/config/manager/manager.yaml
+++ b/controlplane/config/manager/manager.yaml
@@ -24,6 +24,7 @@ spec:
         - "--leader-elect"
         - "--diagnostics-address=${CAPRKE2_DIAGNOSTICS_ADDRESS:=:8443}"
         - "--insecure-diagnostics=${CAPRKE2_INSECURE_DIAGNOSTICS:=false}"
+        - "--v=${CAPRKE2_DEBUG_LEVEL:=0}"
         image: controller:latest
         name: manager
         env:

--- a/controlplane/internal/controllers/rke2controlplane_controller.go
+++ b/controlplane/internal/controllers/rke2controlplane_controller.go
@@ -357,7 +357,7 @@ func (r *RKE2ControlPlaneReconciler) updateStatus(ctx context.Context, rcp *cont
 		return err
 	}
 
-	rcp.Status.UpdatedReplicas = rke2util.SafeInt32(len(controlPlane.UpToDateMachines()))
+	rcp.Status.UpdatedReplicas = rke2util.SafeInt32(len(controlPlane.UpToDateMachines(ctx)))
 	replicas := rke2util.SafeInt32(len(ownedMachines))
 	desiredReplicas := *rcp.Spec.Replicas
 
@@ -636,7 +636,7 @@ func (r *RKE2ControlPlaneReconciler) reconcileNormal(
 	}
 
 	// Control plane machines rollout due to configuration changes (e.g. upgrades) takes precedence over other operations.
-	needRollout := controlPlane.MachinesNeedingRollout()
+	needRollout := controlPlane.MachinesNeedingRollout(ctx)
 
 	switch {
 	case len(needRollout) > 0:

--- a/pkg/rke2/machine_filters.go
+++ b/pkg/rke2/machine_filters.go
@@ -181,20 +181,29 @@ func matchesTemplateClonedFrom(ctx context.Context,
 			return true
 		}
 
+		infraName := rcp.Spec.MachineTemplate.InfrastructureRef.Name
+		infraGroupKind := rcp.Spec.MachineTemplate.InfrastructureRef.GroupVersionKind().GroupKind().String()
+		// Legacy support. Prevent rollout before the deprecated InfrastructureRef is moved to MachineTemplate
+		// If MachineTemplate has not been populated yet, use deprecated reference.
+		if rcp.Spec.InfrastructureRef.Name != "" && rcp.Spec.MachineTemplate.InfrastructureRef.Name == "" {
+			infraName = rcp.Spec.InfrastructureRef.Name
+			infraGroupKind = rcp.Spec.InfrastructureRef.GroupVersionKind().GroupKind().String()
+		}
+
 		// Check if the machine's infrastructure reference has been created from the current RCP infrastructure template.
-		if clonedFromName != rcp.Spec.MachineTemplate.InfrastructureRef.Name {
+		if clonedFromName != infraName {
 			logger.V(5).Info(fmt.Sprintf("Machine template name changed from %s to %s. Needs rollout",
 				clonedFromName,
-				rcp.Spec.MachineTemplate.InfrastructureRef.Name),
+				infraName),
 			)
 
 			return false
 		}
 
-		if clonedFromGroupKind != rcp.Spec.MachineTemplate.InfrastructureRef.GroupVersionKind().GroupKind().String() {
+		if clonedFromGroupKind != infraGroupKind {
 			logger.V(5).Info(fmt.Sprintf("Machine template GroupKind changed from %s to %s. Needs rollout",
 				clonedFromGroupKind,
-				rcp.Spec.MachineTemplate.InfrastructureRef.GroupVersionKind().GroupKind().String()),
+				infraGroupKind),
 			)
 
 			return false

--- a/pkg/rke2/machine_filters_test.go
+++ b/pkg/rke2/machine_filters_test.go
@@ -1,6 +1,8 @@
 package rke2
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -65,7 +67,7 @@ var machine = clusterv1.Machine{
 
 var _ = Describe("ServerConfigMatching", func() {
 	It("should match the machine annotation", func() {
-		res := matchServerConfig(&rcp, &machine)
+		res := matchServerConfig(context.TODO(), &rcp, &machine)
 		Expect(res).To(BeTrue())
 	})
 })
@@ -88,7 +90,7 @@ var _ = Describe("matchAgentConfig", func() {
 		}
 		machineCollection := collections.FromMachines(&machine)
 		Expect(len(machineCollection)).To(Equal(1))
-		matches := machineCollection.AnyFilter(matchesRKE2BootstrapConfig(machineConfigs, &rcp))
+		matches := machineCollection.AnyFilter(matchesRKE2BootstrapConfig(context.TODO(), machineConfigs, &rcp))
 
 		Expect(len(matches)).To(Equal(1))
 		Expect(matches.Oldest().Name).To(Equal("machine-test"))
@@ -113,7 +115,7 @@ var _ = Describe("matchAgentConfig", func() {
 		}
 		machineCollection := collections.FromMachines(&machine)
 		Expect(len(machineCollection)).To(Equal(1))
-		matches := machineCollection.AnyFilter(matchesRKE2BootstrapConfig(machineConfigs, &rcp))
+		matches := machineCollection.AnyFilter(matchesRKE2BootstrapConfig(context.TODO(), machineConfigs, &rcp))
 
 		Expect(len(matches)).To(Equal(0))
 	},
@@ -137,7 +139,7 @@ var _ = Describe("matchAgentConfig", func() {
 		}
 		machineCollection := collections.FromMachines(&machine)
 		Expect(len(machineCollection)).To(Equal(1))
-		matches := machineCollection.AnyFilter(matchesRKE2BootstrapConfig(machineConfigs, &rcp))
+		matches := machineCollection.AnyFilter(matchesRKE2BootstrapConfig(context.TODO(), machineConfigs, &rcp))
 
 		Expect(len(matches)).To(Equal(0))
 	},
@@ -147,14 +149,14 @@ var _ = Describe("matchAgentConfig", func() {
 var _ = Describe("matching Kubernetes Version", func() {
 	It("should match version", func() {
 		machineCollection := collections.FromMachines(&machine)
-		matches := machineCollection.AnyFilter(matchesKubernetesOrRKE2Version(rcp.GetDesiredVersion()))
+		matches := machineCollection.AnyFilter(matchesKubernetesOrRKE2Version(context.TODO(), rcp.GetDesiredVersion()))
 		Expect(len(matches)).To(Equal(1))
 	})
 
 	It("should match when RKE2 version is set on the machine", func() {
 		machine.Spec.Version = &rke2MachineVersion
 		machineCollection := collections.FromMachines(&machine)
-		matches := machineCollection.AnyFilter(matchesKubernetesOrRKE2Version(rcp.GetDesiredVersion()))
+		matches := machineCollection.AnyFilter(matchesKubernetesOrRKE2Version(context.TODO(), rcp.GetDesiredVersion()))
 		Expect(len(matches)).To(Equal(1))
 		machine.Spec.Version = &k8sMachineVersion
 	})

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -145,6 +145,7 @@ variables:
   EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION: "true"
   EXP_MACHINE_POOL: "true"
   CLUSTER_TOPOLOGY: "true"
+  CAPRKE2_DEBUG_LEVEL: "5"
 
 intervals:
   default/wait-controllers: ["3m", "10s"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Backport of https://github.com/rancher/cluster-api-provider-rke2/pull/651

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
