### PR TITLE
Fix private registry token authentication

### DIFF
--- a/docs/book/src/02_topics/04_embedded-registry.md
+++ b/docs/book/src/02_topics/04_embedded-registry.md
@@ -1,10 +1,12 @@
 # Configuring Embedded Registry in RKE2
 
 ## Overview
+
 RKE2 allows users to enable an **embedded registry** on control plane nodes. When the `embeddedRegistry` option is set to `true` in the `serverConfig`, users can configure the registry using the `PrivateRegistriesConfig` field.
 The process follows [RKE2 docs](https://docs.rke2.io/install/registry_mirror).
 
 ## Enabling Embedded Registry
+
 To enable the embedded registry, set the `embeddedRegistry` field to `true` in the `serverConfig` section of the `RKE2ControlPlane` configuration:
 
 ```yaml
@@ -18,6 +20,7 @@ spec:
 ```
 
 ## Configuring Private Registries
+
 Once the embedded registry is enabled, you can configure private registries using the `PrivateRegistriesConfig` field in `RKE2ConfigSpec`. This field allows you to define registry mirrors, authentication, and TLS settings.
 
 Example:
@@ -38,14 +41,25 @@ spec:
       "myregistry.example.com":
         authSecret:
           name: my-registry-secret
+          namespace: my-secrets-namespace
         tls:
           tlsConfigSecret:
             name: my-registry-tls-secret
+            namespace: my-secrets-namespace
           insecureSkipVerify: false
 ```
 
 ## TLS Secret Format
+
 When configuring the `tlsConfigSecret`, ensure the secret contains the following keys:
+
 - **`ca.crt`** – CA certificate
 - **`tls.key`** – TLS private key
 - **`tls.crt`** – TLS certificate
+
+## Auth Secret Format
+
+When configuring the `authSecret`, ensure the secret contains the following keys:
+
+- **`username` and `password`** - When using Basic Auth credentials
+- **`identity-token`** - When using a personal access token

--- a/pkg/rke2/registries_types.go
+++ b/pkg/rke2/registries_types.go
@@ -49,7 +49,7 @@ type AuthConfig struct {
 	Auth string `json:"auth,omitempty" toml:"auth" yaml:"auth,omitempty"`
 	// IdentityToken is used to authenticate the user and get
 	// an access token for the registry.
-	IdentityToken string `json:"identity_token,omitempty" toml:"identitytoken" yaml:"identity_token,omitempty"`
+	IdentityToken string `json:"token,omitempty" toml:"token" yaml:"token,omitempty"`
 }
 
 // TLSConfig contains the CA/Cert/Key used for a registry.


### PR DESCRIPTION
**What this PR does / why we need it**:
As per [documentation](https://docs.rke2.io/install/private_registry#registries-configuration-file), the `identity-token` key is actually `token`, not `identity_token`.

Not sure if this changed in the past, but I just tried and it fails:
```bash
# cat /etc/rancher/rke2/registries.yaml 
configs:
  docker.io:
    auth:
      identity_token: dckr_pat_foobar
```

while this works fine:
```bash
# cat /etc/rancher/rke2/registries.yaml 
configs:
  docker.io:
    auth:
      token: dckr_pat_foobar
```

Tested on `v1.31.4+rke2r1`

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
