### PR TITLE
Pass AdditionalUserData.Data to NewJoinControlPlane

### DIFF
--- a/bootstrap/internal/controllers/rke2config_controller.go
+++ b/bootstrap/internal/controllers/rke2config_controller.go
@@ -687,16 +687,17 @@ func (r *RKE2ConfigReconciler) joinControlplane(ctx context.Context, scope *Scop
 
 	cpinput := &cloudinit.ControlPlaneInput{
 		BaseUserData: cloudinit.BaseUserData{
-			AirGapped:           scope.Config.Spec.AgentConfig.AirGapped,
-			AirGappedChecksum:   scope.Config.Spec.AgentConfig.AirGappedChecksum,
-			CISEnabled:          scope.Config.Spec.AgentConfig.CISProfile != "",
-			PreRKE2Commands:     scope.Config.Spec.PreRKE2Commands,
-			PostRKE2Commands:    scope.Config.Spec.PostRKE2Commands,
-			ConfigFile:          initConfigFile,
-			RKE2Version:         scope.GetDesiredVersion(),
-			WriteFiles:          files,
-			NTPServers:          ntpServers,
-			AdditionalCloudInit: scope.Config.Spec.AgentConfig.AdditionalUserData.Config,
+			AirGapped:               scope.Config.Spec.AgentConfig.AirGapped,
+			AirGappedChecksum:       scope.Config.Spec.AgentConfig.AirGappedChecksum,
+			CISEnabled:              scope.Config.Spec.AgentConfig.CISProfile != "",
+			PreRKE2Commands:         scope.Config.Spec.PreRKE2Commands,
+			PostRKE2Commands:        scope.Config.Spec.PostRKE2Commands,
+			ConfigFile:              initConfigFile,
+			RKE2Version:             scope.GetDesiredVersion(),
+			WriteFiles:              files,
+			NTPServers:              ntpServers,
+			AdditionalCloudInit:     scope.Config.Spec.AgentConfig.AdditionalUserData.Config,
+			AdditionalArbitraryData: scope.Config.Spec.AgentConfig.AdditionalUserData.Data,
 		},
 	}
 


### PR DESCRIPTION
The same way it's passed to NewInitControlPlane.

Fixes #677.

**What this PR does / why we need it**:

Additional cloud-init data was not being added to the bootstrap secret for control plane nodes because it's not being passed along.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #677

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
