### PR TITLE
Configures usage of feature-gate & manager flags

### DIFF
--- a/bootstrap/config/manager/manager.yaml
+++ b/bootstrap/config/manager/manager.yaml
@@ -21,11 +21,12 @@ spec:
       - command:
         - /manager
         args:
-        - --leader-elect
+        - "--leader-elect"
         - "--diagnostics-address=${CAPRKE2_DIAGNOSTICS_ADDRESS:=:8443}"
         - "--insecure-diagnostics=${CAPRKE2_INSECURE_DIAGNOSTICS:=false}"
-        - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=true}"
         - "--v=${CAPRKE2_DEBUG_LEVEL:=0}"
+        - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=true}"
+        - "--concurrency=${CONCURRENCY_NUMBER:=10}"
         image: controller:latest
         name: manager
         ports:

--- a/controlplane/config/manager/manager.yaml
+++ b/controlplane/config/manager/manager.yaml
@@ -25,6 +25,7 @@ spec:
         - "--diagnostics-address=${CAPRKE2_DIAGNOSTICS_ADDRESS:=:8443}"
         - "--insecure-diagnostics=${CAPRKE2_INSECURE_DIAGNOSTICS:=false}"
         - "--v=${CAPRKE2_DEBUG_LEVEL:=0}"
+        - "--concurrency=${CONCURRENCY_NUMBER:=10}"
         image: controller:latest
         name: manager
         env:

--- a/docs/book/src/02_topics/05_configure-manager-options.md
+++ b/docs/book/src/02_topics/05_configure-manager-options.md
@@ -1,0 +1,46 @@
+## Supported Manager Options
+
+At present, the following feature gates and flags are supported for configuration.
+
+### Feature Gates
+
+| Name            | Description                                           | Default | Env Variable     |
+|-----------------|-------------------------------------------------------|---------|------------------|
+| MachinePool     | for MachinePool functionality                         | true    | EXP_MACHINE_POOL |
+| ClusterTopology | for ClusterClass and managed topologies functionality | true    | CLUSTER_TOPOLOGY |
+
+### Flags
+
+| Name        | Description                                                        | Default | Env Variable       |
+|-------------|--------------------------------------------------------------------|---------|--------------------|
+| concurrency | Number of core resources to process simultaneously                 | 10      | CONCURRENCY_NUMBER |
+
+## Configuring Manager Options
+In order to configure the manager options, it is required to patch the respective values in the 
+`rke2-bootstrap-controller-manager` and `rke2-control-plane-controller-manager` deployments.
+
+- Enable/Disable the feature flags:
+> **Note:** Enabling/Disabling feature gates is supported only for `rke2-bootstrap-controller-manager`.
+```shell
+$ kubectl -n system edit deployment/rke2-bootstrap-controller-manager 
+
+// Enable/disable available features by modifying args below.
+    args:
+      ...
+    - "--feature-gates=MachinePool=true,ClusterResourceSet=true"
+```
+
+- Configure the concurrency options for manager:
+> **Note:** Configuring manager options is supported for `rke2-bootstrap-controller-manager` as well as `rke2-control-plane-controller-manager`.
+
+- Update `concurrency` arg:
+```shell
+$ kubectl -n system edit deployment/controller-manager
+
+// Modify the value of  --concurrency  in args
+   args:
+      ...
+    - "--concurrency=<required_value>"
+```
+
+The patch shall rollout the deployment, and should spin up new pods with updated values.

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -8,6 +8,7 @@
     - [Node registration methods](./02_topics/02_node-registration-methods.md)
     - [CIS and PSA](./02_topics/03_cis-psa.md)
     - [Embedded registry](./02_topics/04_embedded-registry.md)
+    - [Configuring manager options](./02_topics/05_configure-manager-options.md)
 - [Examples](./03_examples/00.md)
     - [AWS](./03_examples/01_aws.md)
     - [vSphere](./03_examples/02_vsphere.md)


### PR DESCRIPTION
kind/feature
kind/documentation

**What this PR does / why we need it**:
Allows configuring following feature-gate & manager flags:
- ClusterTopology : featureGate
- namespace : flag
- concurrency  : flag

Fixes #588 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
