### PR TITLE
Use go.mod to setup go version in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version-file: go.mod
           check-latest: true
           cache: true
       - name: Verify

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version-file: go.mod
       - name: Setup kind
         uses: helm/kind-action@v1.12.0
         with:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23.0
+          go-version-file: go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8.0.0
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,6 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23.0
+          go-version-file: go.mod
       - name: Lint
         run: make lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     - name: setupGo
       uses: actions/setup-go@v5
       with:
-        go-version: '=1.23.0'
+        go-version-file: go.mod
     - name: Docker login ghcr.io
       uses: docker/login-action@v3
       with:
@@ -62,7 +62,7 @@ jobs:
     - name: setupGo
       uses: actions/setup-go@v5
       with:
-        go-version: '=1.23.0'
+        go-version-file: go.mod
     - name: Update manifests
       run: |
         make release RELEASE_TAG=${{ env.TAG }} REGISTRY=${{ env.GHCR_REGISTRY }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes the hardcoded go versions in all workflows. `go.mod` is now the source of truth.
This should fix dependabot bumps like: https://github.com/rancher/cluster-api-provider-rke2/pull/728/files

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
