### PR TITLE
Add SystemDefaultRegistry to AgentConfig

### DIFF
--- a/pkg/rke2/config.go
+++ b/pkg/rke2/config.go
@@ -467,6 +467,8 @@ type rke2AgentConfig struct {
 	PauseImage      string `yaml:"pause-image,omitempty"`
 	PrivateRegistry string `yaml:"private-registry,omitempty"`
 
+	SystemDefaultRegistry string `yaml:"system-default-registry,omitempty"`
+
 	NodeExternalIp string `yaml:"node-external-ip,omitempty"`
 	NodeIp         string `yaml:"node-ip,omitempty"`
 	NodeName       string `yaml:"node-name,omitempty"`
@@ -610,6 +612,7 @@ func newRKE2AgentConfig(opts AgentConfigOpts) (*rke2AgentConfig, []bootstrapv1.F
 	}
 
 	rke2AgentConfig.Token = opts.Token
+	rke2AgentConfig.SystemDefaultRegistry = opts.AgentConfig.SystemDefaultRegistry
 
 	return rke2AgentConfig, files, nil
 }

--- a/pkg/rke2/config_test.go
+++ b/pkg/rke2/config_test.go
@@ -302,7 +302,8 @@ var _ = Describe("RKE2 Agent Config", func() {
 					Name:      "test",
 					Namespace: "test",
 				},
-				KubeletPath: "testpath",
+				SystemDefaultRegistry: "testregistry",
+				KubeletPath:           "testpath",
 				Kubelet: &bootstrapv1.ComponentConfig{
 					ExtraArgs: []string{"testarg"},
 				},
@@ -329,7 +330,7 @@ var _ = Describe("RKE2 Agent Config", func() {
 		}
 	})
 
-	It("should succefully generate an agent config", func() {
+	It("should successfully generate an agent config", func() {
 		agentConfig, files, err := GenerateWorkerConfig(*opts)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -354,6 +355,7 @@ var _ = Describe("RKE2 Agent Config", func() {
 		Expect(agentConfig.KubeProxyExtraMounts).To(Equal(componentMapToSlice(extraMount, opts.AgentConfig.KubeProxy.ExtraMounts)))
 		Expect(agentConfig.KubeProxyExtraEnv).To(Equal(componentMapToSlice(extraEnv, opts.AgentConfig.KubeProxy.ExtraEnv)))
 		Expect(agentConfig.Token).To(Equal(opts.Token))
+		Expect(agentConfig.SystemDefaultRegistry).To(Equal(opts.AgentConfig.SystemDefaultRegistry))
 
 		Expect(files).To(HaveLen(3))
 


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->
kind/bug
**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
Add the missing `SystemDefaultRegistry` to `AgentConfig`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #723

**Special notes for your reviewer**:
<details><summary>I used the following <code>RKE2ControlPlane</code> to test.</summary>
<p>

```yaml
apiVersion: controlplane.cluster.x-k8s.io/v1beta1
kind: RKE2ControlPlane
metadata:
  name: pvala-rke2-system-default-registry-control-plane
  namespace: pvala-ns
spec: 
  replicas: 1
  version: v1.31.7+rke2r1
  registrationMethod: control-plane-endpoint
  rolloutStrategy:
    type: "RollingUpdate"
    rollingUpdate:
      maxSurge: 1
  agentConfig:
    systemDefaultRegistry: docker.io
  gzipUserData: false
  serverConfig:
    disableComponents:
      kubernetesComponents:
      - cloudController
    kubeAPIServer:
      extraArgs:
      - --anonymous-auth=true
  machineTemplate:
    infrastructureRef:
      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
      kind: DockerMachineTemplate
      name: controlplane
    nodeDrainTimeout: 2m
    nodeDeletionTimeout: 30s
    nodeVolumeDetachTimeout: 5m
```

</p>
</details>

<details><summary><code>cat /etc/rancher/rke2/config.yaml</code></summary>
<p>

```sh
root@pvala-rke2-system-default-registry-control-plane-mh6mj:/# cat /etc/rancher/rke2/config.yaml

disable-cloud-controller: true
kube-apiserver-arg:
  - --anonymous-auth=true
tls-san:
  - 172.18.0.3
cluster-cidr: 10.45.0.0/16
service-cidr: 10.46.0.0/16
token: f8272fe69e90d3723cc0b7efd45e4f34
system-default-registry: docker.io

```

</p>
</details> 

<details><summary><code>k get secret pvala-rke2-system-default-registry-control-plane-s29d6 -npvala-ns -ojson</code></summary>
<p>

```yaml
      
-   path: /etc/rancher/rke2/config.yaml
    owner: root:root
    permissions: '0640'
    content: |
      disable-cloud-controller: true
      kube-apiserver-arg:
        - --anonymous-auth=true
      tls-san:
        - 172.18.0.3
      cluster-cidr: 10.45.0.0/16
      service-cidr: 10.46.0.0/16
      token: f8272fe69e90d3723cc0b7efd45e4f34
      system-default-registry: docker.io
```

</p>
</details> 

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
