### PR TITLE
[fix] Return error on missing k8s version

### DIFF
--- a/bootstrap/internal/controllers/rke2config_controller.go
+++ b/bootstrap/internal/controllers/rke2config_controller.go
@@ -404,6 +404,13 @@ func (r *RKE2ConfigReconciler) handleClusterNotInitialized(ctx context.Context, 
 		registrationAddress = scope.ControlPlane.Spec.RegistrationAddress
 	}
 
+	version, err := scope.GetDesiredVersion()
+	if err != nil {
+		scope.Logger.Error(err, "RKE2 version does not seem to be set")
+
+		return ctrl.Result{}, err
+	}
+
 	configStruct, configFiles, err := rke2.GenerateInitControlPlaneConfig(
 		rke2.ServerConfigOpts{
 			Cluster:              *scope.Cluster,
@@ -414,7 +421,7 @@ func (r *RKE2ConfigReconciler) handleClusterNotInitialized(ctx context.Context, 
 			AgentConfig:          scope.Config.Spec.AgentConfig,
 			Ctx:                  ctx,
 			Client:               r.Client,
-			Version:              scope.GetDesiredVersion(),
+			Version:              version,
 		})
 	if err != nil {
 		return ctrl.Result{}, err
@@ -476,7 +483,7 @@ func (r *RKE2ConfigReconciler) handleClusterNotInitialized(ctx context.Context, 
 			PreRKE2Commands:         scope.Config.Spec.PreRKE2Commands,
 			PostRKE2Commands:        scope.Config.Spec.PostRKE2Commands,
 			ConfigFile:              initConfigFile,
-			RKE2Version:             scope.GetDesiredVersion(),
+			RKE2Version:             version,
 			WriteFiles:              files,
 			NTPServers:              ntpServers,
 			AdditionalCloudInit:     scope.Config.Spec.AgentConfig.AdditionalUserData.Config,
@@ -638,6 +645,13 @@ func (r *RKE2ConfigReconciler) joinControlplane(ctx context.Context, scope *Scop
 		return ctrl.Result{RequeueAfter: DefaultRequeueAfter}, nil
 	}
 
+	version, err := scope.GetDesiredVersion()
+	if err != nil {
+		scope.Logger.Error(err, "RKE2 version does not seem to be set")
+
+		return ctrl.Result{}, err
+	}
+
 	configStruct, configFiles, err := rke2.GenerateJoinControlPlaneConfig(
 		rke2.ServerConfigOpts{
 			Cluster:              *scope.Cluster,
@@ -648,7 +662,7 @@ func (r *RKE2ConfigReconciler) joinControlplane(ctx context.Context, scope *Scop
 			AgentConfig:          scope.Config.Spec.AgentConfig,
 			Ctx:                  ctx,
 			Client:               r.Client,
-			Version:              scope.GetDesiredVersion(),
+			Version:              version,
 		},
 	)
 	if err != nil {
@@ -713,7 +727,7 @@ func (r *RKE2ConfigReconciler) joinControlplane(ctx context.Context, scope *Scop
 			PreRKE2Commands:         scope.Config.Spec.PreRKE2Commands,
 			PostRKE2Commands:        scope.Config.Spec.PostRKE2Commands,
 			ConfigFile:              initConfigFile,
-			RKE2Version:             scope.GetDesiredVersion(),
+			RKE2Version:             version,
 			WriteFiles:              files,
 			NTPServers:              ntpServers,
 			AdditionalCloudInit:     scope.Config.Spec.AgentConfig.AdditionalUserData.Config,
@@ -774,6 +788,13 @@ func (r *RKE2ConfigReconciler) joinWorker(ctx context.Context, scope *Scope) (re
 		return ctrl.Result{RequeueAfter: DefaultRequeueAfter}, nil
 	}
 
+	version, err := scope.GetDesiredVersion()
+	if err != nil {
+		scope.Logger.Error(err, "RKE2 version does not seem to be set")
+
+		return ctrl.Result{}, err
+	}
+
 	configStruct, configFiles, err := rke2.GenerateWorkerConfig(
 		rke2.AgentConfigOpts{
 			ServerURL:              fmt.Sprintf(serverURLFormat, scope.ControlPlane.Status.AvailableServerIPs[0], registrationPort),
@@ -783,7 +804,7 @@ func (r *RKE2ConfigReconciler) joinWorker(ctx context.Context, scope *Scope) (re
 			Client:                 r.Client,
 			CloudProviderName:      scope.ControlPlane.Spec.ServerConfig.CloudProviderName,
 			CloudProviderConfigMap: scope.ControlPlane.Spec.ServerConfig.CloudProviderConfigMap,
-			Version:                scope.GetDesiredVersion(),
+			Version:                version,
 		})
 	if err != nil {
 		return ctrl.Result{}, err
@@ -826,7 +847,7 @@ func (r *RKE2ConfigReconciler) joinWorker(ctx context.Context, scope *Scope) (re
 		CISEnabled:              scope.Config.Spec.AgentConfig.CISProfile != "",
 		PostRKE2Commands:        scope.Config.Spec.PostRKE2Commands,
 		ConfigFile:              wkJoinConfigFile,
-		RKE2Version:             scope.GetDesiredVersion(),
+		RKE2Version:             version,
 		WriteFiles:              files,
 		NTPServers:              ntpServers,
 		AdditionalCloudInit:     scope.Config.Spec.AgentConfig.AdditionalUserData.Config,

--- a/bootstrap/internal/controllers/rke2config_scope.go
+++ b/bootstrap/internal/controllers/rke2config_scope.go
@@ -42,6 +42,8 @@ var (
 	ErrRKE2ConfigNotFound = errors.New("RKE2Config is not found")
 	// ErrNoRKE2ConfigOwner describes the RKE2Config has no Machine or MachinePool owner.
 	ErrNoRKE2ConfigOwner = errors.New("RKE2Config has no owner")
+	// ErrVersionNotFound describes the desired K8S version can not be found.
+	ErrVersionNotFound = errors.New("RKE2 version can not be found")
 )
 
 // Scope is a scoped struct used during reconciliation.
@@ -143,10 +145,14 @@ func (s *Scope) HasControlPlaneOwner() bool {
 }
 
 // GetDesiredVersion returns the K8S version associated to the RKE2Config owner.
-func (s *Scope) GetDesiredVersion() string {
-	if s.MachinePool != nil {
-		return *s.MachinePool.Spec.Template.Spec.Version
+func (s *Scope) GetDesiredVersion() (string, error) {
+	if s.MachinePool != nil && s.MachinePool.Spec.Template.Spec.Version != nil {
+		return *s.MachinePool.Spec.Template.Spec.Version, nil
 	}
 
-	return *s.Machine.Spec.Version
+	if s.Machine != nil && s.Machine.Spec.Version != nil {
+		return *s.Machine.Spec.Version, nil
+	}
+
+	return "", ErrVersionNotFound
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes a panic when `version` is not set. Also returns a contextualized error message.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #750 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
