### PR TITLE
Add additional DisabledPluginComponent options for Traefik

### DIFF
--- a/controlplane/api/v1beta1/rke2controlplane_types.go
+++ b/controlplane/api/v1beta1/rke2controlplane_types.go
@@ -492,7 +492,7 @@ const (
 	CloudController DisabledKubernetesComponent = "cloudController"
 )
 
-//+kubebuilder:validation:Enum=rke2-coredns;rke2-ingress-nginx;rke2-metrics-server;rke2-snapshot-controller;rke2-snapshot-controller-crd;rke2-snapshot-validation-webhook
+//+kubebuilder:validation:Enum=rke2-coredns;rke2-ingress-nginx;rke2-metrics-server;rke2-snapshot-controller;rke2-snapshot-controller-crd;rke2-snapshot-validation-webhook;rke2-traefik;rke2-traefik-crd
 
 // DisabledPluginComponent selects a plugin Components to be disabled.
 type DisabledPluginComponent string
@@ -510,6 +510,10 @@ const (
 	SnapshotControllerCRD DisabledPluginComponent = "rke2-snapshot-controller-crd"
 	// SnapshotValidationWebhook references the RKE2 Plugin "rke2-snapshot-validation-webhook".
 	SnapshotValidationWebhook DisabledPluginComponent = "rke2-snapshot-validation-webhook"
+	// Traefik references the RKE2 Plugin "rke2-traefik".
+	Traefik DisabledPluginComponent = "rke2-traefik"
+	// TraefikCRD references the RKE2 Plugin "rke2-traefik-crd".
+	TraefikCRD DisabledPluginComponent = "rke2-traefik-crd"
 )
 
 // RemediationStrategy allows to define how control plane machine remediation happens.

--- a/controlplane/api/v1beta2/rke2controlplane_types.go
+++ b/controlplane/api/v1beta2/rke2controlplane_types.go
@@ -472,7 +472,7 @@ const (
 	CloudController DisabledKubernetesComponent = "cloudController"
 )
 
-//+kubebuilder:validation:Enum=rke2-coredns;rke2-ingress-nginx;rke2-metrics-server;rke2-snapshot-controller;rke2-snapshot-controller-crd;rke2-snapshot-validation-webhook
+//+kubebuilder:validation:Enum=rke2-coredns;rke2-ingress-nginx;rke2-metrics-server;rke2-snapshot-controller;rke2-snapshot-controller-crd;rke2-snapshot-validation-webhook;rke2-traefik;rke2-traefik-crd
 
 // DisabledPluginComponent selects a plugin Components to be disabled.
 type DisabledPluginComponent string
@@ -490,6 +490,10 @@ const (
 	SnapshotControllerCRD DisabledPluginComponent = "rke2-snapshot-controller-crd"
 	// SnapshotValidationWebhook references the RKE2 Plugin "rke2-snapshot-validation-webhook".
 	SnapshotValidationWebhook DisabledPluginComponent = "rke2-snapshot-validation-webhook"
+	// Traefik references the RKE2 Plugin "rke2-traefik".
+	Traefik DisabledPluginComponent = "rke2-traefik"
+	// TraefikCRD references the RKE2 Plugin "rke2-traefik-crd".
+	TraefikCRD DisabledPluginComponent = "rke2-traefik-crd"
 )
 
 // RemediationStrategy allows to define how control plane machine remediation happens.

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanes.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanes.yaml
@@ -1022,6 +1022,8 @@ spec:
                           - rke2-snapshot-controller
                           - rke2-snapshot-controller-crd
                           - rke2-snapshot-validation-webhook
+                          - rke2-traefik
+                          - rke2-traefik-crd
                           type: string
                         type: array
                     type: object
@@ -2665,6 +2667,8 @@ spec:
                           - rke2-snapshot-controller
                           - rke2-snapshot-controller-crd
                           - rke2-snapshot-validation-webhook
+                          - rke2-traefik
+                          - rke2-traefik-crd
                           type: string
                         type: array
                     type: object

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanetemplates.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanetemplates.yaml
@@ -1060,6 +1060,8 @@ spec:
                                   - rke2-snapshot-controller
                                   - rke2-snapshot-controller-crd
                                   - rke2-snapshot-validation-webhook
+                                  - rke2-traefik
+                                  - rke2-traefik-crd
                                   type: string
                                 type: array
                             type: object
@@ -2711,6 +2713,8 @@ spec:
                                   - rke2-snapshot-controller
                                   - rke2-snapshot-controller-crd
                                   - rke2-snapshot-validation-webhook
+                                  - rke2-traefik
+                                  - rke2-traefik-crd
                                   type: string
                                 type: array
                             type: object


### PR DESCRIPTION
kind/feature

**What this PR does / why we need it**:

This PR extends the list of supported `serverConfig.disableComponents.pluginComponents` values to include the RKE2 Traefik packaged components:

- rke2-traefik
- rke2-traefik-crd

This allows users to disable Traefik from `RKE2ControlPlane` / `RKE2ControlPlaneTemplate` in the same way other RKE2-managed addons can already be disabled.

This is useful for environments where ingress management is handled independently from the RKE2 installation lifecycle, avoiding the deployment of unnecessary packaged components while keeping the cluster configuration fully declarative through Cluster API.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #918

**Special notes for your reviewer**:

This change only extends the kubebuilder validation enum and generated CRDs to accept the missing RKE2 Traefik packaged component names.

**Checklist**:

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
