### PR TITLE
fix: only raise CVE PRs on release branches

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,16 @@
   "prHourlyLimit": 2,
   "packageRules": [
     {
+      "description": "Only raise PRs for CVE/vulnerability fixes on release branches.",
+      "matchBaseBranches": [
+        "/^release-.*/"
+      ],
+      "matchJsonata": [
+        "$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Cluster API and its dependencies are upgraded manually.",
       "matchManagers": [
         "gomod"


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Fixes #988 

Added a rule to avoid creating PRs against release branches that are not targeting CVEs. This is so that we reduce the PR noise.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
