### PR TITLE
feat: add resolvConfPath to configure the RKE2 resolv-conf option

### DIFF
--- a/bootstrap/api/v1beta1/rke2config_types.go
+++ b/bootstrap/api/v1beta1/rke2config_types.go
@@ -63,6 +63,7 @@ type RKE2ConfigSpec struct {
 }
 
 // RKE2AgentConfig describes some attributes that are common to agent and server nodes.
+// +kubebuilder:validation:XValidation:rule="!has(self.resolvConf) || !has(self.resolvConfPath)",message="only one of resolvConf or resolvConfPath may be set"
 type RKE2AgentConfig struct {
 	// DataDir Folder to hold state.
 	//+optional
@@ -116,8 +117,18 @@ type RKE2AgentConfig struct {
 	PodSecurityAdmissionConfigFile string `json:"podSecurityAdmissionConfigFile,omitempty"`
 
 	// ResolvConf is a reference to a ConfigMap containing resolv.conf content for the node.
+	// The content is written to /etc/rancher/rke2/resolv.conf, and RKE2 is pointed at that file.
+	// Mutually exclusive with ResolvConfPath.
 	//+optional
 	ResolvConf *corev1.ObjectReference `json:"resolvConf,omitempty"`
+
+	// ResolvConfPath is the path of a resolv.conf file that already exists on the node, passed to
+	// RKE2 as the kubelet resolver configuration (for example /run/systemd/resolve/resolv.conf on
+	// systemd-resolved based distributions). Unlike ResolvConf, no file is created on the node.
+	// Mutually exclusive with ResolvConf.
+	// +kubebuilder:validation:Pattern=`^/.*`
+	//+optional
+	ResolvConfPath string `json:"resolvConfPath,omitempty"`
 
 	// ProtectKernelDefaults defines Kernel tuning behavior. If true, error if kernel tunables are different than kubelet defaults.
 	// if false, kernel tunable can be different from kubelet defaults

--- a/bootstrap/api/v1beta1/zz_generated.conversion.go
+++ b/bootstrap/api/v1beta1/zz_generated.conversion.go
@@ -464,6 +464,7 @@ func autoConvert_v1beta1_RKE2AgentConfig_To_v1beta2_RKE2AgentConfig(in *RKE2Agen
 	out.CISProfile = v1beta2.CISProfile(in.CISProfile)
 	out.PodSecurityAdmissionConfigFile = in.PodSecurityAdmissionConfigFile
 	out.ResolvConf = (*corev1.ObjectReference)(unsafe.Pointer(in.ResolvConf))
+	out.ResolvConfPath = in.ResolvConfPath
 	out.ProtectKernelDefaults = in.ProtectKernelDefaults
 	out.SystemDefaultRegistry = in.SystemDefaultRegistry
 	out.EnableContainerdSElinux = in.EnableContainerdSElinux
@@ -494,6 +495,7 @@ func autoConvert_v1beta2_RKE2AgentConfig_To_v1beta1_RKE2AgentConfig(in *v1beta2.
 	out.CISProfile = CISProfile(in.CISProfile)
 	out.PodSecurityAdmissionConfigFile = in.PodSecurityAdmissionConfigFile
 	out.ResolvConf = (*corev1.ObjectReference)(unsafe.Pointer(in.ResolvConf))
+	out.ResolvConfPath = in.ResolvConfPath
 	out.ProtectKernelDefaults = in.ProtectKernelDefaults
 	out.SystemDefaultRegistry = in.SystemDefaultRegistry
 	out.EnableContainerdSElinux = in.EnableContainerdSElinux

--- a/bootstrap/api/v1beta2/rke2config_resolvconf_test.go
+++ b/bootstrap/api/v1beta2/rke2config_resolvconf_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026 SUSE LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("RKE2Config resolv.conf validation", func() {
+	newConfig := func(name string, agentConfig RKE2AgentConfig) *RKE2Config {
+		return &RKE2Config{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: metav1.NamespaceDefault,
+			},
+			Spec: RKE2ConfigSpec{
+				AgentConfig: agentConfig,
+			},
+		}
+	}
+
+	It("should accept resolvConfPath on its own", func() {
+		config := newConfig("resolv-conf-path-only", RKE2AgentConfig{
+			ResolvConfPath: "/run/systemd/resolve/resolv.conf",
+		})
+
+		Expect(k8sClient.Create(ctx, config)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, config)).To(Succeed())
+	})
+
+	It("should accept resolvConf on its own", func() {
+		config := newConfig("resolv-conf-only", RKE2AgentConfig{
+			ResolvConf: &corev1.ObjectReference{
+				Name:      "test",
+				Namespace: metav1.NamespaceDefault,
+			},
+		})
+
+		Expect(k8sClient.Create(ctx, config)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, config)).To(Succeed())
+	})
+
+	It("should reject resolvConf and resolvConfPath set together", func() {
+		config := newConfig("resolv-conf-both", RKE2AgentConfig{
+			ResolvConf: &corev1.ObjectReference{
+				Name:      "test",
+				Namespace: metav1.NamespaceDefault,
+			},
+			ResolvConfPath: "/run/systemd/resolve/resolv.conf",
+		})
+
+		err := k8sClient.Create(ctx, config)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("only one of resolvConf or resolvConfPath may be set"))
+	})
+
+	It("should reject a relative resolvConfPath", func() {
+		config := newConfig("resolv-conf-relative", RKE2AgentConfig{
+			ResolvConfPath: "run/systemd/resolve/resolv.conf",
+		})
+
+		Expect(k8sClient.Create(ctx, config)).ToNot(Succeed())
+	})
+})

--- a/bootstrap/api/v1beta2/rke2config_types.go
+++ b/bootstrap/api/v1beta2/rke2config_types.go
@@ -61,6 +61,7 @@ type RKE2ConfigSpec struct {
 }
 
 // RKE2AgentConfig describes some attributes that are common to agent and server nodes.
+// +kubebuilder:validation:XValidation:rule="!has(self.resolvConf) || !has(self.resolvConfPath)",message="only one of resolvConf or resolvConfPath may be set"
 type RKE2AgentConfig struct {
 	// DataDir Folder to hold state.
 	//+optional
@@ -114,8 +115,18 @@ type RKE2AgentConfig struct {
 	PodSecurityAdmissionConfigFile string `json:"podSecurityAdmissionConfigFile,omitempty"`
 
 	// ResolvConf is a reference to a ConfigMap containing resolv.conf content for the node.
+	// The content is written to /etc/rancher/rke2/resolv.conf, and RKE2 is pointed at that file.
+	// Mutually exclusive with ResolvConfPath.
 	//+optional
 	ResolvConf *corev1.ObjectReference `json:"resolvConf,omitempty"`
+
+	// ResolvConfPath is the path of a resolv.conf file that already exists on the node, passed to
+	// RKE2 as the kubelet resolver configuration (for example /run/systemd/resolve/resolv.conf on
+	// systemd-resolved based distributions). Unlike ResolvConf, no file is created on the node.
+	// Mutually exclusive with ResolvConf.
+	// +kubebuilder:validation:Pattern=`^/.*`
+	//+optional
+	ResolvConfPath string `json:"resolvConfPath,omitempty"`
 
 	// ProtectKernelDefaults defines Kernel tuning behavior. If true, error if kernel tunables are different than kubelet defaults.
 	// if false, kernel tunable can be different from kubelet defaults

--- a/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_rke2configs.yaml
+++ b/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_rke2configs.yaml
@@ -261,8 +261,10 @@ spec:
                       if false, kernel tunable can be different from kubelet defaults
                     type: boolean
                   resolvConf:
-                    description: ResolvConf is a reference to a ConfigMap containing
-                      resolv.conf content for the node.
+                    description: |-
+                      ResolvConf is a reference to a ConfigMap containing resolv.conf content for the node.
+                      The content is written to /etc/rancher/rke2/resolv.conf, and RKE2 is pointed at that file.
+                      Mutually exclusive with ResolvConfPath.
                     properties:
                       apiVersion:
                         description: API version of the referent.
@@ -304,6 +306,14 @@ spec:
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
+                  resolvConfPath:
+                    description: |-
+                      ResolvConfPath is the path of a resolv.conf file that already exists on the node, passed to
+                      RKE2 as the kubelet resolver configuration (for example /run/systemd/resolve/resolv.conf on
+                      systemd-resolved based distributions). Unlike ResolvConf, no file is created on the node.
+                      Mutually exclusive with ResolvConf.
+                    pattern: ^/.*
+                    type: string
                   runtimeImage:
                     description: RuntimeImage override image to use for runtime binaries
                       (containerd, kubectl, crictl, etc).
@@ -317,6 +327,9 @@ spec:
                       for all system images.
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: only one of resolvConf or resolvConfPath may be set
+                  rule: '!has(self.resolvConf) || !has(self.resolvConfPath)'
               files:
                 description: Files specifies extra files to be passed to user_data
                   upon creation.
@@ -955,8 +968,10 @@ spec:
                       if false, kernel tunable can be different from kubelet defaults
                     type: boolean
                   resolvConf:
-                    description: ResolvConf is a reference to a ConfigMap containing
-                      resolv.conf content for the node.
+                    description: |-
+                      ResolvConf is a reference to a ConfigMap containing resolv.conf content for the node.
+                      The content is written to /etc/rancher/rke2/resolv.conf, and RKE2 is pointed at that file.
+                      Mutually exclusive with ResolvConfPath.
                     properties:
                       apiVersion:
                         description: API version of the referent.
@@ -998,6 +1013,14 @@ spec:
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
+                  resolvConfPath:
+                    description: |-
+                      ResolvConfPath is the path of a resolv.conf file that already exists on the node, passed to
+                      RKE2 as the kubelet resolver configuration (for example /run/systemd/resolve/resolv.conf on
+                      systemd-resolved based distributions). Unlike ResolvConf, no file is created on the node.
+                      Mutually exclusive with ResolvConf.
+                    pattern: ^/.*
+                    type: string
                   runtimeImage:
                     description: RuntimeImage override image to use for runtime binaries
                       (containerd, kubectl, crictl, etc).
@@ -1011,6 +1034,9 @@ spec:
                       for all system images.
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: only one of resolvConf or resolvConfPath may be set
+                  rule: '!has(self.resolvConf) || !has(self.resolvConfPath)'
               files:
                 description: Files specifies extra files to be passed to user_data
                   upon creation.

--- a/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_rke2configtemplates.yaml
+++ b/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_rke2configtemplates.yaml
@@ -281,8 +281,10 @@ spec:
                               if false, kernel tunable can be different from kubelet defaults
                             type: boolean
                           resolvConf:
-                            description: ResolvConf is a reference to a ConfigMap
-                              containing resolv.conf content for the node.
+                            description: |-
+                              ResolvConf is a reference to a ConfigMap containing resolv.conf content for the node.
+                              The content is written to /etc/rancher/rke2/resolv.conf, and RKE2 is pointed at that file.
+                              Mutually exclusive with ResolvConfPath.
                             properties:
                               apiVersion:
                                 description: API version of the referent.
@@ -324,6 +326,14 @@ spec:
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
+                          resolvConfPath:
+                            description: |-
+                              ResolvConfPath is the path of a resolv.conf file that already exists on the node, passed to
+                              RKE2 as the kubelet resolver configuration (for example /run/systemd/resolve/resolv.conf on
+                              systemd-resolved based distributions). Unlike ResolvConf, no file is created on the node.
+                              Mutually exclusive with ResolvConf.
+                            pattern: ^/.*
+                            type: string
                           runtimeImage:
                             description: RuntimeImage override image to use for runtime
                               binaries (containerd, kubectl, crictl, etc).
@@ -337,6 +347,10 @@ spec:
                               be used for all system images.
                             type: string
                         type: object
+                        x-kubernetes-validations:
+                        - message: only one of resolvConf or resolvConfPath may be
+                            set
+                          rule: '!has(self.resolvConf) || !has(self.resolvConfPath)'
                       files:
                         description: Files specifies extra files to be passed to user_data
                           upon creation.
@@ -860,8 +874,10 @@ spec:
                               if false, kernel tunable can be different from kubelet defaults
                             type: boolean
                           resolvConf:
-                            description: ResolvConf is a reference to a ConfigMap
-                              containing resolv.conf content for the node.
+                            description: |-
+                              ResolvConf is a reference to a ConfigMap containing resolv.conf content for the node.
+                              The content is written to /etc/rancher/rke2/resolv.conf, and RKE2 is pointed at that file.
+                              Mutually exclusive with ResolvConfPath.
                             properties:
                               apiVersion:
                                 description: API version of the referent.
@@ -903,6 +919,14 @@ spec:
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
+                          resolvConfPath:
+                            description: |-
+                              ResolvConfPath is the path of a resolv.conf file that already exists on the node, passed to
+                              RKE2 as the kubelet resolver configuration (for example /run/systemd/resolve/resolv.conf on
+                              systemd-resolved based distributions). Unlike ResolvConf, no file is created on the node.
+                              Mutually exclusive with ResolvConf.
+                            pattern: ^/.*
+                            type: string
                           runtimeImage:
                             description: RuntimeImage override image to use for runtime
                               binaries (containerd, kubectl, crictl, etc).
@@ -916,6 +940,10 @@ spec:
                               be used for all system images.
                             type: string
                         type: object
+                        x-kubernetes-validations:
+                        - message: only one of resolvConf or resolvConfPath may be
+                            set
+                          rule: '!has(self.resolvConf) || !has(self.resolvConfPath)'
                       files:
                         description: Files specifies extra files to be passed to user_data
                           upon creation.

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanes.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanes.yaml
@@ -261,8 +261,10 @@ spec:
                       if false, kernel tunable can be different from kubelet defaults
                     type: boolean
                   resolvConf:
-                    description: ResolvConf is a reference to a ConfigMap containing
-                      resolv.conf content for the node.
+                    description: |-
+                      ResolvConf is a reference to a ConfigMap containing resolv.conf content for the node.
+                      The content is written to /etc/rancher/rke2/resolv.conf, and RKE2 is pointed at that file.
+                      Mutually exclusive with ResolvConfPath.
                     properties:
                       apiVersion:
                         description: API version of the referent.
@@ -304,6 +306,14 @@ spec:
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
+                  resolvConfPath:
+                    description: |-
+                      ResolvConfPath is the path of a resolv.conf file that already exists on the node, passed to
+                      RKE2 as the kubelet resolver configuration (for example /run/systemd/resolve/resolv.conf on
+                      systemd-resolved based distributions). Unlike ResolvConf, no file is created on the node.
+                      Mutually exclusive with ResolvConf.
+                    pattern: ^/.*
+                    type: string
                   runtimeImage:
                     description: RuntimeImage override image to use for runtime binaries
                       (containerd, kubectl, crictl, etc).
@@ -317,6 +327,9 @@ spec:
                       for all system images.
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: only one of resolvConf or resolvConfPath may be set
+                  rule: '!has(self.resolvConf) || !has(self.resolvConfPath)'
               files:
                 description: Files specifies extra files to be passed to user_data
                   upon creation.
@@ -1962,8 +1975,10 @@ spec:
                       if false, kernel tunable can be different from kubelet defaults
                     type: boolean
                   resolvConf:
-                    description: ResolvConf is a reference to a ConfigMap containing
-                      resolv.conf content for the node.
+                    description: |-
+                      ResolvConf is a reference to a ConfigMap containing resolv.conf content for the node.
+                      The content is written to /etc/rancher/rke2/resolv.conf, and RKE2 is pointed at that file.
+                      Mutually exclusive with ResolvConfPath.
                     properties:
                       apiVersion:
                         description: API version of the referent.
@@ -2005,6 +2020,14 @@ spec:
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
+                  resolvConfPath:
+                    description: |-
+                      ResolvConfPath is the path of a resolv.conf file that already exists on the node, passed to
+                      RKE2 as the kubelet resolver configuration (for example /run/systemd/resolve/resolv.conf on
+                      systemd-resolved based distributions). Unlike ResolvConf, no file is created on the node.
+                      Mutually exclusive with ResolvConf.
+                    pattern: ^/.*
+                    type: string
                   runtimeImage:
                     description: RuntimeImage override image to use for runtime binaries
                       (containerd, kubectl, crictl, etc).
@@ -2018,6 +2041,9 @@ spec:
                       for all system images.
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: only one of resolvConf or resolvConfPath may be set
+                  rule: '!has(self.resolvConf) || !has(self.resolvConfPath)'
               files:
                 description: Files specifies extra files to be passed to user_data
                   upon creation.

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanetemplates.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanetemplates.yaml
@@ -305,8 +305,10 @@ spec:
                               if false, kernel tunable can be different from kubelet defaults
                             type: boolean
                           resolvConf:
-                            description: ResolvConf is a reference to a ConfigMap
-                              containing resolv.conf content for the node.
+                            description: |-
+                              ResolvConf is a reference to a ConfigMap containing resolv.conf content for the node.
+                              The content is written to /etc/rancher/rke2/resolv.conf, and RKE2 is pointed at that file.
+                              Mutually exclusive with ResolvConfPath.
                             properties:
                               apiVersion:
                                 description: API version of the referent.
@@ -348,6 +350,14 @@ spec:
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
+                          resolvConfPath:
+                            description: |-
+                              ResolvConfPath is the path of a resolv.conf file that already exists on the node, passed to
+                              RKE2 as the kubelet resolver configuration (for example /run/systemd/resolve/resolv.conf on
+                              systemd-resolved based distributions). Unlike ResolvConf, no file is created on the node.
+                              Mutually exclusive with ResolvConf.
+                            pattern: ^/.*
+                            type: string
                           runtimeImage:
                             description: RuntimeImage override image to use for runtime
                               binaries (containerd, kubectl, crictl, etc).
@@ -361,6 +371,10 @@ spec:
                               be used for all system images.
                             type: string
                         type: object
+                        x-kubernetes-validations:
+                        - message: only one of resolvConf or resolvConfPath may be
+                            set
+                          rule: '!has(self.resolvConf) || !has(self.resolvConfPath)'
                       files:
                         description: Files specifies extra files to be passed to user_data
                           upon creation.
@@ -2042,8 +2056,10 @@ spec:
                               if false, kernel tunable can be different from kubelet defaults
                             type: boolean
                           resolvConf:
-                            description: ResolvConf is a reference to a ConfigMap
-                              containing resolv.conf content for the node.
+                            description: |-
+                              ResolvConf is a reference to a ConfigMap containing resolv.conf content for the node.
+                              The content is written to /etc/rancher/rke2/resolv.conf, and RKE2 is pointed at that file.
+                              Mutually exclusive with ResolvConfPath.
                             properties:
                               apiVersion:
                                 description: API version of the referent.
@@ -2085,6 +2101,14 @@ spec:
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
+                          resolvConfPath:
+                            description: |-
+                              ResolvConfPath is the path of a resolv.conf file that already exists on the node, passed to
+                              RKE2 as the kubelet resolver configuration (for example /run/systemd/resolve/resolv.conf on
+                              systemd-resolved based distributions). Unlike ResolvConf, no file is created on the node.
+                              Mutually exclusive with ResolvConf.
+                            pattern: ^/.*
+                            type: string
                           runtimeImage:
                             description: RuntimeImage override image to use for runtime
                               binaries (containerd, kubectl, crictl, etc).
@@ -2098,6 +2122,10 @@ spec:
                               be used for all system images.
                             type: string
                         type: object
+                        x-kubernetes-validations:
+                        - message: only one of resolvConf or resolvConfPath may be
+                            set
+                          rule: '!has(self.resolvConf) || !has(self.resolvConfPath)'
                       files:
                         description: Files specifies extra files to be passed to user_data
                           upon creation.

--- a/pkg/rke2/config.go
+++ b/pkg/rke2/config.go
@@ -609,6 +609,10 @@ func newRKE2AgentConfig(opts AgentConfigOpts) (*rke2AgentConfig, []bootstrapv1.F
 	rke2AgentConfig.ProtectKernelDefaults = opts.AgentConfig.ProtectKernelDefaults
 	rke2AgentConfig.PodSecurityAdmissionConfigFile = opts.AgentConfig.PodSecurityAdmissionConfigFile
 
+	if opts.AgentConfig.ResolvConfPath != "" {
+		rke2AgentConfig.ResolvConf = opts.AgentConfig.ResolvConfPath
+	}
+
 	if opts.AgentConfig.ResolvConf != nil {
 		resolvConfCM := &corev1.ConfigMap{}
 		if err := opts.Client.Get(opts.Ctx, types.NamespacedName{

--- a/pkg/rke2/config_test.go
+++ b/pkg/rke2/config_test.go
@@ -440,6 +440,23 @@ var _ = Describe("RKE2 Agent Config", func() {
 		Expect(files[2].Owner).To(Equal(consts.DefaultFileOwner))
 		Expect(files[2].Permissions).To(Equal(consts.DefaultFileMode))
 	})
+
+	It("should use ResolvConfPath verbatim and not write a resolv.conf file", func() {
+		opts.AgentConfig.ResolvConf = nil
+		opts.AgentConfig.ResolvConfPath = "/run/systemd/resolve/resolv.conf"
+
+		agentConfig, files, err := GenerateWorkerConfig(*opts)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(agentConfig.ResolvConf).To(Equal("/run/systemd/resolve/resolv.conf"))
+
+		// Only the CIS script and the image credential provider config are written,
+		// no resolv.conf is materialised on the node.
+		Expect(files).To(HaveLen(2))
+		for _, file := range files {
+			Expect(file.Path).ToNot(Equal("/etc/rancher/rke2/resolv.conf"))
+		}
+	})
 })
 
 var _ = Describe("componentMapToSlice", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

RKE2ConfigTemplate and RKE2ControlPlaneTemplate had no way to point RKE2 at a resolver file that already exists on the node. The existing agentConfig.resolvConf field takes a ConfigMap reference whose contents are written to `/etc/rancher/rke2/resolv.conf`, so it cannot reference a path such as `/run/systemd/resolve/resolv.conf` used on `systemd-resolved` based distributions. The only workaround was injecting a `config.yaml.d` snippet through `spec.files`.

Add `agentConfig.resolvConfPath`, which is passed straight through to the RKE2 resolv-conf option without materialising a file on the node. As RKE2ControlPlane inlines RKE2ConfigSpec, the field is exposed by both the bootstrap and control plane templates.

The two fields map to the same RKE2 option, so a CEL rule rejects setting both, and resolvConfPath is constrained to absolute paths.

Fixes #920

**Special notes for your reviewer**:

**Checklist**:
- [X] squashed commits into logical changes
- [X] includes documentation
- [X] adds unit tests
- [X] adds or updates e2e tests
