### PR TITLE
docs: document that manifestsConfigMapReference changes do not trigger rollout

### DIFF
--- a/controlplane/api/v1beta1/rke2controlplane_types.go
+++ b/controlplane/api/v1beta1/rke2controlplane_types.go
@@ -91,6 +91,8 @@ type RKE2ControlPlaneSpec struct {
 
 	// ManifestsConfigMapReference references a ConfigMap which contains Kubernetes manifests to be deployed automatically on the cluster
 	// Each data entry in the ConfigMap will be will be copied to a folder on the control plane nodes that RKE2 scans and uses to deploy manifests.
+	// Changes to the ConfigMap content or reference do not trigger a control plane rollout. New content only reaches control plane
+	// Machines created after the change. Use spec.files instead if content changes must trigger a rollout on existing Machines.
 	//+optional
 	ManifestsConfigMapReference corev1.ObjectReference `json:"manifestsConfigMapReference,omitempty"`
 

--- a/controlplane/api/v1beta2/rke2controlplane_types.go
+++ b/controlplane/api/v1beta2/rke2controlplane_types.go
@@ -91,6 +91,8 @@ type RKE2ControlPlaneSpec struct {
 
 	// ManifestsConfigMapReference references a ConfigMap which contains Kubernetes manifests to be deployed automatically on the cluster
 	// Each data entry in the ConfigMap will be will be copied to a folder on the control plane nodes that RKE2 scans and uses to deploy manifests.
+	// Changes to the ConfigMap content or reference do not trigger a control plane rollout. New content only reaches control plane
+	// Machines created after the change. Use spec.files instead if content changes must trigger a rollout on existing Machines.
 	//+optional
 	ManifestsConfigMapReference corev1.ObjectReference `json:"manifestsConfigMapReference,omitempty,omitzero"`
 

--- a/controlplane/api/v1beta2/rke2controlplanetemplate_types.go
+++ b/controlplane/api/v1beta2/rke2controlplanetemplate_types.go
@@ -57,6 +57,8 @@ type RKE2ControlPlaneTemplateResourceSpec struct {
 
 	// ManifestsConfigMapReference references a ConfigMap which contains Kubernetes manifests to be deployed automatically on the cluster
 	// Each data entry in the ConfigMap will be will be copied to a folder on the control plane nodes that RKE2 scans and uses to deploy manifests.
+	// Changes to the ConfigMap content or reference do not trigger a control plane rollout. New content only reaches control plane
+	// Machines created after the change. Use spec.files instead if content changes must trigger a rollout on existing Machines.
 	//+optional
 	ManifestsConfigMapReference corev1.ObjectReference `json:"manifestsConfigMapReference,omitempty,omitzero"`
 

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanes.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanes.yaml
@@ -556,6 +556,8 @@ spec:
                 description: |-
                   ManifestsConfigMapReference references a ConfigMap which contains Kubernetes manifests to be deployed automatically on the cluster
                   Each data entry in the ConfigMap will be will be copied to a folder on the control plane nodes that RKE2 scans and uses to deploy manifests.
+                  Changes to the ConfigMap content or reference do not trigger a control plane rollout. New content only reaches control plane
+                  Machines created after the change. Use spec.files instead if content changes must trigger a rollout on existing Machines.
                 properties:
                   apiVersion:
                     description: API version of the referent.
@@ -2236,6 +2238,8 @@ spec:
                 description: |-
                   ManifestsConfigMapReference references a ConfigMap which contains Kubernetes manifests to be deployed automatically on the cluster
                   Each data entry in the ConfigMap will be will be copied to a folder on the control plane nodes that RKE2 scans and uses to deploy manifests.
+                  Changes to the ConfigMap content or reference do not trigger a control plane rollout. New content only reaches control plane
+                  Machines created after the change. Use spec.files instead if content changes must trigger a rollout on existing Machines.
                 properties:
                   apiVersion:
                     description: API version of the referent.

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanetemplates.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanetemplates.yaml
@@ -606,6 +606,8 @@ spec:
                         description: |-
                           ManifestsConfigMapReference references a ConfigMap which contains Kubernetes manifests to be deployed automatically on the cluster
                           Each data entry in the ConfigMap will be will be copied to a folder on the control plane nodes that RKE2 scans and uses to deploy manifests.
+                          Changes to the ConfigMap content or reference do not trigger a control plane rollout. New content only reaches control plane
+                          Machines created after the change. Use spec.files instead if content changes must trigger a rollout on existing Machines.
                         properties:
                           apiVersion:
                             description: API version of the referent.
@@ -2323,6 +2325,8 @@ spec:
                         description: |-
                           ManifestsConfigMapReference references a ConfigMap which contains Kubernetes manifests to be deployed automatically on the cluster
                           Each data entry in the ConfigMap will be will be copied to a folder on the control plane nodes that RKE2 scans and uses to deploy manifests.
+                          Changes to the ConfigMap content or reference do not trigger a control plane rollout. New content only reaches control plane
+                          Machines created after the change. Use spec.files instead if content changes must trigger a rollout on existing Machines.
                         properties:
                           apiVersion:
                             description: API version of the referent.

--- a/docs/book/src/02_topics/10_manifests_configmap_rollout.md
+++ b/docs/book/src/02_topics/10_manifests_configmap_rollout.md
@@ -1,0 +1,49 @@
+# Manifests ConfigMap and control plane rollout
+
+## Overview
+
+`RKE2ControlPlane.spec.manifestsConfigMapReference` points to a `ConfigMap`.
+Each data entry in the `ConfigMap` is copied to a folder on the control
+plane nodes. RKE2 scans this folder and deploys the manifests it finds.
+
+Changes to the `ConfigMap` do not trigger a control plane rollout. This
+applies to both the `ConfigMap` content and the `manifestsConfigMapReference`
+value itself.
+
+## Behavior
+
+New content from the `ConfigMap` reaches a control plane Machine only when
+RKE2 provisions that Machine. This happens in 2 cases:
+
+1. You create a new control plane Machine.
+2. An unrelated change, for example a Kubernetes version upgrade, triggers a
+   rollout of existing control plane Machines.
+
+If you edit the `ConfigMap` and no rollout happens for another reason,
+existing control plane Machines keep their current manifests. Only new
+Machines get the updated content.
+
+## Manifests that must roll out with the ConfigMap
+
+Use `spec.files` on the `RKE2ControlPlane` if you need a manifest to trigger a
+rollout on existing control plane Machines. Changes to `spec.files` do
+trigger a rollout.
+
+Example:
+
+```yaml
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: RKE2ControlPlane
+metadata:
+  name: my-control-plane
+spec:
+  files:
+    - path: /var/lib/rancher/rke2/server/manifests/my-manifest.yaml
+      content: |
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: example
+      owner: "root:root"
+      permissions: "0644"
+```

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -13,6 +13,7 @@
     - [External load balancer exclusion](./02_topics/07_load_balancer_exclusion.md)
     - [External datastore](./02_topics/08_external_datastore.md)
     - [Secrets encryption](./02_topics/09_secrets_encryption.md)
+    - [Manifests ConfigMap and control plane rollout](./02_topics/10_manifests_configmap_rollout.md)
 - [Examples](./03_examples/00.md)
     - [AWS](./03_examples/01_aws.md)
     - [vSphere](./03_examples/02_vsphere.md)


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:
kind/documentation
-->

**What this PR does / why we need it**:

`RKE2ControlPlane.spec.manifestsConfigMapReference` (and the equivalent
field on `RKE2ControlPlaneTemplate`) references a ConfigMap whose content
is copied to a folder on control plane nodes for RKE2 to scan and deploy.
Changes to the ConfigMap content or reference do not trigger a control
plane rollout — new content only reaches Machines created after the
change, for example during an unrelated version upgrade.

This was undocumented and read as a bug. This PR documents the current
behavior:
- Updates the field's API doc comment in both `v1beta1` and `v1beta2`
  types, and regenerates the CRDs (`make generate-manifests`).
- Adds a topic page under `docs/book/src/02_topics/` describing the
  behavior and the `spec.files` alternative for manifests that must
  trigger a rollout on existing Machines.

**Which issue(s) this PR fixes**:
Fixes #921

**Special notes for your reviewer**:

No code/behavior change — documentation only, per discussion on #921.

**Checklist**:

- [x] squashed commits into logical changes
- [x] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

